### PR TITLE
SDK-1298: Doc Scan

### DIFF
--- a/Examples/Yoti.Auth.Sandbox.Examples/DocScanSandboxExample.cs
+++ b/Examples/Yoti.Auth.Sandbox.Examples/DocScanSandboxExample.cs
@@ -1,0 +1,130 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Yoti.Auth.Sandbox.DocScan.Request;
+using Yoti.Auth.Sandbox.DocScan.Request.Check;
+using Yoti.Auth.Sandbox.DocScan.Request.Check.Report;
+using Yoti.Auth.Sandbox.DocScan.Request.Task;
+
+namespace Yoti.Auth.Sandbox.Examples
+{
+    [TestClass]
+    public class DocScanSandboxExample
+    {
+        [TestMethod]
+        public void TestDocScan()
+        {
+            Org.BouncyCastle.Crypto.AsymmetricCipherKeyPair sandboxKeyPair;
+
+            using (StreamReader stream = File.OpenText("path/to/hub-private-key.pem"))
+            {
+                sandboxKeyPair = Yoti.Auth.CryptoEngine.LoadRsaKey(stream);
+            }
+
+            const string sandboxClientSdkid = "your SDK ID";
+
+            var responseConfig = new ResponseConfigBuilder()
+                .WithCheckReports(
+                    (new SandboxCheckReportsBuilder())
+                        .WithAsyncReportDelay(10)
+                        .WithDocumentAuthenticityCheck(
+                            new SandboxDocumentAuthenticityCheckBuilder()
+                                .WithBreakdown(
+                                    (new SandboxBreakdownBuilder())
+                                        .WithSubCheck("security_features")
+                                        .WithResult("NOT_AVAILABLE")
+                                        .WithDetail(new SandboxDetail("some_detail", "some_detail_value"))
+                                        .Build()
+                                )
+                                .WithRecommendation(
+                                    (new SandboxRecommendationBuilder())
+                                        .WithValue("NOT_AVAILABLE")
+                                        .WithReason("PICTURE_TOO_DARK")
+                                        .WithRecoverySuggestion("BETTER_LIGHTING")
+                                        .Build()
+                                )
+                                .Build()
+                        )
+                        .WithDocumentFaceMatchCheck(
+                            new SandboxDocumentFaceMatchCheckBuilder()
+                                .WithBreakdown(
+                                    (new SandboxBreakdownBuilder())
+                                        .WithSubCheck("security_features")
+                                        .WithResult("PASS")
+                                        .Build()
+                                )
+                                .WithRecommendation(
+                                    (new SandboxRecommendationBuilder())
+                                        .WithValue("APPROVE")
+                                        .Build()
+                                )
+                                .Build()
+                        )
+                        .WithDocumentTextDataCheck(
+                            new SandboxDocumentTextDataCheckBuilder()
+                                .WithDocumentFields(
+                                new Dictionary<string, object>
+                                {
+                                    { "full_name", "John Doe" },
+                                    { "full_name", "John Doe"},
+                                    { "nationality", "GBR"},
+                                    { "date_of_birth", "1986-06-01"},
+                                    { "document_number", "123456789"}
+                                })
+                                .WithBreakdown(
+                                    new SandboxBreakdownBuilder()
+                                        .WithSubCheck("document_in_date")
+                                        .WithResult("PASS")
+                                        .Build()
+                                )
+                                .WithRecommendation(
+                                    (new SandboxRecommendationBuilder())
+                                        .WithValue("APPROVE")
+                                        .Build()
+                                )
+                                .Build()
+                        )
+                        .WithLivenessCheck(
+                            (new SandboxZoomLivenessCheckBuilder())
+                                .WithBreakdown(
+                                    (new SandboxBreakdownBuilder())
+                                        .WithSubCheck("security_features")
+                                        .WithResult("PASS")
+                                        .Build()
+                                )
+                                .WithRecommendation(
+                                    (new SandboxRecommendationBuilder())
+                                        .WithValue("APPROVE")
+                                        .Build()
+                                )
+                                .Build()
+                        )
+                        .Build()
+    )
+    .WithTaskResults(
+        (new SandboxTaskResultsBuilder())
+            .WithDocumentTextDataExtractionTask(
+                new SandboxDocumentTextDataExtractionTaskBuilder()
+                    .WithDocumentFields(
+                        new Dictionary<string, object>
+                        {
+                            { "full_name", "John Doe" },
+                            { "full_name", "John Doe"},
+                            { "nationality", "GBR"},
+                            { "date_of_birth", "1986-06-01"},
+                            { "document_number", "123456789"}
+                        })
+                    .Build()
+            )
+            .Build()
+    )
+    .Build();
+
+            var client = new SandboxClientBuilder()
+                .WithClientSdkId(sandboxClientSdkid)
+                .WithKeyPair(sandboxKeyPair)
+                .Build();
+            client.ConfigureSessionResponse("SESSION_ID", responseConfig);
+        }
+    }
+}

--- a/Examples/Yoti.Auth.Sandbox.Examples/ProfileSandboxExample.cs
+++ b/Examples/Yoti.Auth.Sandbox.Examples/ProfileSandboxExample.cs
@@ -1,0 +1,75 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Yoti.Auth.Sandbox.Profile;
+using Yoti.Auth.Sandbox.Profile.Request;
+using Yoti.Auth.Sandbox.Profile.Request.Attribute.Derivation;
+
+namespace Yoti.Auth.Sandbox.Examples
+{
+    [TestClass]
+    public class ProfileSandboxExample
+    {
+        [TestMethod]
+        public void TestProfile()
+        {
+            Org.BouncyCastle.Crypto.AsymmetricCipherKeyPair sandboxKeyPair;
+
+            using (StreamReader stream = File.OpenText("path/to/hub-private-key.pem"))
+            {
+                sandboxKeyPair = Yoti.Auth.CryptoEngine.LoadRsaKey(stream);
+            }
+
+            const string sandboxClientSdkid = "your SDK ID";
+
+            SandboxClient sandboxClient = new SandboxClientBuilder()
+                .WithClientSdkId(sandboxClientSdkid)
+                .WithKeyPair(sandboxKeyPair)
+                .Build();
+
+            SandboxAgeVerification ageVerification = new SandboxAgeVerificationBuilder()
+                .WithDateOfBirth(new DateTime(2001, 12, 31))
+                .WithAgeOver(18)
+                .Build();
+
+            YotiTokenRequest tokenRequest = new YotiTokenRequestBuilder()
+                .WithRememberMeId("some Remember Me ID")
+                .WithGivenNames("some given names")
+                .WithFamilyName("some family name")
+                .WithFullName("some full name")
+                .WithDateOfBirth(new DateTime(1980, 10, 30))
+                .WithAgeVerification(ageVerification)
+                .WithGender("some gender")
+                .WithPhoneNumber("some phone number")
+                .WithNationality("some nationality")
+                .WithStructuredPostalAddress(Newtonsoft.Json.JsonConvert.SerializeObject(new
+                {
+                    building_number = 1,
+                    address_line1 = "some address"
+                }))
+                .WithBase64Selfie(Convert.ToBase64String(Encoding.UTF8.GetBytes("some base64 encoded selfie")))
+                .WithEmailAddress("some@email")
+                .WithDocumentDetails("PASSPORT USA 1234abc")
+                .Build();
+
+            var sandboxOneTimeUseToken = sandboxClient.SetupSharingProfile(tokenRequest);
+
+            var yotiClient = new YotiClient(new HttpClient(), sandboxClientSdkid, sandboxKeyPair);
+
+            Uri sandboxUri = new UriBuilder(
+                "https",
+                "api.yoti.com",
+                443,
+                "sandbox/v1").Uri;
+
+            yotiClient.OverrideApiUri(sandboxUri);
+
+            ActivityDetails activityDetails = yotiClient.GetActivityDetails(sandboxOneTimeUseToken);
+
+            // Perform tests
+            Assert.AreEqual("some@email", activityDetails.Profile.EmailAddress.GetValue());
+        }
+    }
+}

--- a/Examples/Yoti.Auth.Sandbox.Examples/Yoti.Auth.Sandbox.Examples.csproj
+++ b/Examples/Yoti.Auth.Sandbox.Examples/Yoti.Auth.Sandbox.Examples.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Yoti.Auth.Sandbox\Yoti.Auth.Sandbox.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Yoti Sandbox.sln
+++ b/Yoti Sandbox.sln
@@ -7,6 +7,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yoti.Auth.Sandbox.Tests", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yoti.Auth.Sandbox", "Yoti.Auth.Sandbox\Yoti.Auth.Sandbox.csproj", "{6D33D6EA-CD5B-4A17-AB30-541C493E7BC9}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{8C2D7B7B-3ADE-4357-AFBE-3FC766471BCE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yoti.Auth.Sandbox.Examples", "Examples\Yoti.Auth.Sandbox.Examples\Yoti.Auth.Sandbox.Examples.csproj", "{FC95D303-86F6-4432-AC72-1E7A4313D457}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,9 +25,16 @@ Global
 		{6D33D6EA-CD5B-4A17-AB30-541C493E7BC9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6D33D6EA-CD5B-4A17-AB30-541C493E7BC9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6D33D6EA-CD5B-4A17-AB30-541C493E7BC9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FC95D303-86F6-4432-AC72-1E7A4313D457}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FC95D303-86F6-4432-AC72-1E7A4313D457}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FC95D303-86F6-4432-AC72-1E7A4313D457}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FC95D303-86F6-4432-AC72-1E7A4313D457}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{FC95D303-86F6-4432-AC72-1E7A4313D457} = {8C2D7B7B-3ADE-4357-AFBE-3FC766471BCE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A84C8AAE-2EC8-4AD0-8661-0E7E99FA542C}

--- a/Yoti.Auth.Sandbox.Tests/DocScan/DocScanSandboxClientBuilderTests.cs
+++ b/Yoti.Auth.Sandbox.Tests/DocScan/DocScanSandboxClientBuilderTests.cs
@@ -1,0 +1,53 @@
+using System;
+using Xunit;
+using Yoti.Auth.Sandbox.DocScan.Request;
+using Yoti.Auth.Tests.Common;
+
+namespace Yoti.Auth.Sandbox.Tests.DocScan
+{
+    public static class DocScanSandboxClientBuilderTests
+    {
+        private const string _someSdkId = "someSdkId";
+        private static readonly Uri _someUri = new Uri("https://www.test.com");
+
+        [Fact]
+        public static void BuilderShouldThrowForMissingSdkId()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+            {
+                new SandboxClientBuilder()
+                .WithApiUri(_someUri)
+                .WithKeyPair(KeyPair.Get())
+                .Build();
+            });
+
+            Assert.Contains("_sdkId", exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public static void BuilderShouldThrowForMissingKey()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+            {
+                new SandboxClientBuilder()
+                .WithApiUri(_someUri)
+                .WithClientSdkId(_someSdkId)
+                .Build();
+            });
+
+            Assert.Contains("keyPair", exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public static void BuilderShouldCreateClient()
+        {
+            var sandboxClient = new SandboxClientBuilder()
+                .WithClientSdkId(_someSdkId)
+                .WithKeyPair(KeyPair.Get())
+                .WithApiUri(_someUri)
+                .Build();
+
+            Assert.NotNull(sandboxClient);
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox.Tests/DocScan/DocScanSandboxClientTests.cs
+++ b/Yoti.Auth.Sandbox.Tests/DocScan/DocScanSandboxClientTests.cs
@@ -1,0 +1,168 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using Moq;
+using Xunit;
+using Yoti.Auth.Sandbox.DocScan.Request;
+using Yoti.Auth.Tests.Common;
+
+namespace Yoti.Auth.Sandbox.Tests.DocScan
+{
+    public class DocScanSandboxClientTests
+    {
+        private const string _someSdkId = "someSdkId";
+        private const string _someSessionId = "someSessionId";
+        private readonly SandboxClient _yotiDocScanSandboxClient;
+        private static readonly Uri _someUri = new Uri("https://www.test.com");
+        private readonly ResponseConfig _sandboxResponseConfig;
+
+        public DocScanSandboxClientTests()
+        {
+            _yotiDocScanSandboxClient = SandboxClient.Builder()
+                .WithApiUri(_someUri)
+                .WithClientSdkId(_someSdkId)
+                .WithKeyPair(KeyPair.Get())
+                .Build();
+
+            _sandboxResponseConfig = new ResponseConfigBuilder().Build();
+        }
+
+        [Fact]
+        public void ConfigureSessionResponseShouldWrapIOException()
+        {
+            var mockJsonConvert = new Mock<Encoding>();
+            mockJsonConvert.Setup(
+                x => x.GetBytes(It.IsAny<string>()))
+                    .Throws(new IOException());
+
+            Assert.Throws<SandboxException>(() =>
+            {
+                _yotiDocScanSandboxClient.ConfigureSessionResponse(
+                    _someSessionId,
+                    _sandboxResponseConfig);
+            });
+        }
+
+        [Fact]
+        public void ConfigureSessionResponseShouldNotThrowException()
+        {
+            using (var httpResponseMessage = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK
+            })
+            {
+                SandboxClient docScanSandboxClient;
+                Mock<HttpMessageHandler> handlerMock = HttpMock.SetupMockMessageHandler(httpResponseMessage);
+
+                using var httpClient = new HttpClient(handlerMock.Object);
+                docScanSandboxClient = SandboxClient.Builder(httpClient)
+                    .WithClientSdkId(_someSdkId)
+                    .WithKeyPair(KeyPair.Get())
+                    .Build();
+
+                docScanSandboxClient.ConfigureSessionResponse(
+                    _someSessionId,
+                    _sandboxResponseConfig);
+            };
+        }
+
+        [Fact]
+        public void ConfigureSessionResponseShouldThrowForNonSuccessCode()
+        {
+            using (var httpResponseMessage = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.BadRequest,
+                Content = new StringContent("{}")
+            })
+            {
+                SandboxClient docScanSandboxClient;
+                Mock<HttpMessageHandler> handlerMock = HttpMock.SetupMockMessageHandler(httpResponseMessage);
+
+                using var httpClient = new HttpClient(handlerMock.Object);
+                docScanSandboxClient = SandboxClient.Builder(httpClient)
+                    .WithClientSdkId(_someSdkId)
+                    .WithKeyPair(KeyPair.Get())
+                    .Build();
+
+                var exception = Assert.Throws<SandboxException>(() =>
+                {
+                    docScanSandboxClient.ConfigureSessionResponse(
+                          _someSessionId,
+                    _sandboxResponseConfig);
+                });
+
+                Assert.Contains("Error when setting up Doc Scan session response", exception.Message, StringComparison.Ordinal);
+            };
+        }
+
+        [Fact]
+        public void ConfigureApplicationResponseShouldWrapIOException()
+        {
+            var mockJsonConvert = new Mock<Encoding>();
+            mockJsonConvert.Setup(
+                x => x.GetBytes(It.IsAny<string>()))
+                    .Throws(new IOException());
+
+            Assert.Throws<SandboxException>(() =>
+            {
+                _yotiDocScanSandboxClient.ConfigureApplicationResponse(
+                    _sandboxResponseConfig);
+            });
+        }
+
+        [Fact]
+        public void ConfigureApplicationResponseShouldNotError()
+        {
+            string tokenValue = "kyHPjq2+Y48cx+9yS/XzmW09jVUylSdhbP+3Q9Tc9p6bCEnyfa8vj38";
+
+            using (var httpResponseMessage = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("{\"token\": \"" + tokenValue + "\"}")
+            })
+            {
+                SandboxClient docScanSandboxClient;
+                Mock<HttpMessageHandler> handlerMock = HttpMock.SetupMockMessageHandler(httpResponseMessage);
+
+                using var httpClient = new HttpClient(handlerMock.Object);
+                docScanSandboxClient = SandboxClient.Builder(httpClient)
+                    .WithClientSdkId(_someSdkId)
+                    .WithKeyPair(KeyPair.Get())
+                    .Build();
+
+                docScanSandboxClient.ConfigureApplicationResponse(
+                    _sandboxResponseConfig);
+            };
+        }
+
+        [Fact]
+        public void ConfigureApplicationResponseShouldThrowForNonSuccessCode()
+        {
+            using (var httpResponseMessage = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.BadRequest,
+                Content = new StringContent("{}")
+            })
+            {
+                SandboxClient docScanSandboxClient;
+                Mock<HttpMessageHandler> handlerMock = HttpMock.SetupMockMessageHandler(httpResponseMessage);
+
+                using var httpClient = new HttpClient(handlerMock.Object);
+                docScanSandboxClient = SandboxClient.Builder(httpClient)
+                    .WithClientSdkId(_someSdkId)
+                    .WithKeyPair(KeyPair.Get())
+                    .Build();
+
+                var exception = Assert.Throws<SandboxException>(() =>
+                {
+                    docScanSandboxClient.ConfigureApplicationResponse(
+                    _sandboxResponseConfig);
+                });
+
+                Assert.Contains("Error when setting up Doc Scan application response", exception.Message, StringComparison.Ordinal);
+            };
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox.Tests/DocScan/Request/Check/SandboxDocumentAuthenticityCheckBuilderTests.cs
+++ b/Yoti.Auth.Sandbox.Tests/DocScan/Request/Check/SandboxDocumentAuthenticityCheckBuilderTests.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Linq;
+using Xunit;
+using Yoti.Auth.Sandbox.DocScan.Request.Check;
+using Yoti.Auth.Sandbox.DocScan.Request.Check.Report;
+
+namespace Yoti.Auth.Sandbox.Tests.DocScan.Request.Check
+{
+    public class SandboxDocumentAuthenticityCheckBuilderTests
+    {
+        private readonly SandboxBreakdown _someBreakDown = new SandboxBreakdown("someSubCheck", "someResult", details: null);
+        private readonly SandboxRecommendation _someRecommendation = new SandboxRecommendation("someValue", "someReason", "someRecoverySuggestion");
+
+        [Fact]
+        public void ShouldNotBuildWithoutRecommendation()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+            {
+                new SandboxDocumentAuthenticityCheckBuilder()
+                .WithBreakdown(_someBreakDown)
+                .Build();
+            });
+
+            Assert.Contains("Recommendation", exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ShouldBuildSandboxDocumentAuthenticityCheck()
+        {
+            var check = new SandboxDocumentAuthenticityCheckBuilder()
+                .WithRecommendation(_someRecommendation)
+                .WithBreakdown(_someBreakDown)
+                .Build();
+
+            Assert.Equal(_someBreakDown, check.Result.Report.Breakdown.Single());
+            Assert.Equal(_someRecommendation, check.Result.Report.Recommendation);
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox.Tests/DocScan/Request/Check/SandboxDocumentFaceMatchCheckBuilderTests.cs
+++ b/Yoti.Auth.Sandbox.Tests/DocScan/Request/Check/SandboxDocumentFaceMatchCheckBuilderTests.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Xunit;
+using Yoti.Auth.Sandbox.DocScan.Request.Check;
+using Yoti.Auth.Sandbox.DocScan.Request.Check.Report;
+
+namespace Yoti.Auth.Sandbox.Tests.DocScan.Request.Check
+{
+    public class SandboxDocumentFaceMatchCheckBuilderTests
+    {
+        private readonly SandboxBreakdown _someBreakDown = new SandboxBreakdown("someSubCheck", "someResult", details: null);
+
+        [Fact]
+        public void ShouldNotBuildWithoutRecommendation()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+            {
+                new SandboxDocumentFaceMatchCheckBuilder()
+                .WithBreakdown(_someBreakDown)
+                .Build();
+            });
+
+            Assert.Contains("Recommendation", exception.Message, StringComparison.Ordinal);
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox.Tests/DocScan/Request/Check/SandboxDocumentTextDataCheckBuilderTests.cs
+++ b/Yoti.Auth.Sandbox.Tests/DocScan/Request/Check/SandboxDocumentTextDataCheckBuilderTests.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Yoti.Auth.Sandbox.DocScan.Request.Check;
+using Yoti.Auth.Sandbox.DocScan.Request.Check.Report;
+
+namespace Yoti.Auth.Sandbox.Tests.DocScan.Request.Check
+{
+    public class SandboxDocumentTextDataCheckBuilderTests
+    {
+        private readonly SandboxBreakdown _someBreakDown = new SandboxBreakdown("someSubCheck", "someResult", details: null);
+        private readonly SandboxRecommendation _someRecommendation = new SandboxRecommendation("someValue", "someReason", "someRecoverySuggestion");
+        private readonly string _someKey = "someName";
+        private readonly string _someValue = "someValue";
+
+        [Fact]
+        public void ShouldNotBuildWithoutRecommendation()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+            {
+                new SandboxDocumentTextDataCheckBuilder()
+                .WithDocumentField("key", "value")
+                .WithBreakdown(_someBreakDown)
+                .Build();
+            });
+
+            Assert.Contains("Recommendation", exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ShouldBuildWithDocumentField()
+        {
+            var check = new SandboxDocumentTextDataCheckBuilder()
+                .WithDocumentField(_someKey, _someValue)
+                .WithBreakdown(_someBreakDown)
+                .WithRecommendation(_someRecommendation)
+                .Build();
+
+            var sandboxTextDataCheckResult = (SandboxDocumentTextDataCheckResult)check.Result;
+
+            var result = sandboxTextDataCheckResult.DocumentFields.Single();
+
+            Assert.Equal(_someKey, result.Key);
+            Assert.Equal(_someValue, result.Value);
+        }
+
+        [Fact]
+        public void ShouldBuildWithDocumentFields()
+        {
+            var documentFields = new Dictionary<string, object>
+            {
+                { _someKey, _someValue },
+                { "key2", "value2" }
+            };
+
+            var check = new SandboxDocumentTextDataCheckBuilder()
+                .WithDocumentFields(documentFields)
+                .WithRecommendation(_someRecommendation)
+                .WithBreakdown(_someBreakDown)
+                .Build();
+
+            var sandboxTextDataCheckResult = (SandboxDocumentTextDataCheckResult)check.Result;
+
+            var result = sandboxTextDataCheckResult.DocumentFields;
+
+            Assert.Equal(2, result.Count);
+            Assert.Equal(_someKey, result.ElementAt(0).Key);
+            Assert.Equal(_someValue, result.ElementAt(0).Value);
+            Assert.Equal("key2", result.ElementAt(1).Key);
+            Assert.Equal("value2", result.ElementAt(1).Value);
+        }
+
+        [Fact]
+        public void ShouldBuildWithChildFunctionAfterParentFunction()
+        {
+            var documentFields = new Dictionary<string, object>
+            {
+                { _someKey, _someValue }
+            };
+
+            var check = new SandboxDocumentTextDataCheckBuilder()
+                .WithRecommendation(_someRecommendation)
+                .WithBreakdown(_someBreakDown)
+                .WithDocumentFields(documentFields)
+                .Build();
+
+            var sandboxTextDataCheckResult = (SandboxDocumentTextDataCheckResult)check.Result;
+
+            var result = sandboxTextDataCheckResult.DocumentFields;
+
+            Assert.Single(result);
+            Assert.Equal(_someKey, result.ElementAt(0).Key);
+            Assert.Equal(_someValue, result.ElementAt(0).Value);
+        }
+
+        [Fact]
+        public void WithDocumentFieldsShouldOverrideWithDocumentField()
+        {
+            var documentFields = new Dictionary<string, object>
+            {
+                { _someKey, _someValue },
+                { "key2", _someValue }
+            };
+
+            var check = new SandboxDocumentTextDataCheckBuilder()
+                .WithDocumentField(_someKey, _someValue)
+                .WithDocumentFields(documentFields)
+                .WithRecommendation(_someRecommendation)
+                .WithBreakdown(_someBreakDown)
+                .Build();
+
+            var sandboxTextDataCheckResult = (SandboxDocumentTextDataCheckResult)check.Result;
+
+            Assert.Equal(2, sandboxTextDataCheckResult.DocumentFields.Count);
+        }
+
+        [Fact]
+        public void WithDocumentFieldShouldAddToDocumentFields()
+        {
+            var documentFields = new Dictionary<string, object>
+            {
+                { "key1", _someValue },
+                { "key2", _someValue }
+            };
+
+            var check = new SandboxDocumentTextDataCheckBuilder()
+                .WithDocumentFields(documentFields)
+                .WithDocumentField(_someKey, _someValue)
+                .WithBreakdown(_someBreakDown)
+                .WithRecommendation(_someRecommendation)
+                .Build();
+
+            var sandboxTextDataCheckResult = (SandboxDocumentTextDataCheckResult)check.Result;
+
+            Assert.Equal(3, sandboxTextDataCheckResult.DocumentFields.Count);
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox.Tests/DocScan/Request/Check/SandboxZoomLivenessCheckBuilderTests.cs
+++ b/Yoti.Auth.Sandbox.Tests/DocScan/Request/Check/SandboxZoomLivenessCheckBuilderTests.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Yoti.Auth.Sandbox.DocScan.Request.Check;
+using Yoti.Auth.Sandbox.DocScan.Request.Check.Report;
+
+namespace Yoti.Auth.Sandbox.Tests.DocScan.Request.Check
+{
+    public class SandboxZoomLivenessCheckBuilderTests
+    {
+        private readonly SandboxBreakdown _someBreakdown = new SandboxBreakdown("someSubCheck", "someResult", details: null);
+        private readonly SandboxRecommendation _someRecommendation = new SandboxRecommendation("someValue", "someReason", "someRecoverySuggestion");
+
+        [Fact]
+        public void ShouldNotBuildWithoutRecommendation()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+            {
+                new SandboxZoomLivenessCheckBuilder()
+                .WithBreakdown(_someBreakdown)
+                .Build();
+            });
+
+            Assert.Contains("Recommendation", exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ShouldBuildWithRecommendation()
+        {
+            string someValue = "someValue";
+            string someReason = "someReason";
+            string someRecoverySuggestion = "someRecoverySuggestion";
+
+            var recommendation = new SandboxRecommendation(someValue, someReason, someRecoverySuggestion);
+
+            var check = new SandboxZoomLivenessCheckBuilder()
+                .WithBreakdown(_someBreakdown)
+                .WithRecommendation(recommendation)
+                .Build();
+
+            var result = check.Result.Report.Recommendation;
+
+            Assert.Equal(someValue, result.Value);
+            Assert.Equal(someReason, result.Reason);
+            Assert.Equal(someRecoverySuggestion, result.RecoverySuggestion);
+        }
+
+        [Fact]
+        public void ShouldBuildWithBreakdown()
+        {
+            string someSubCheck = "someSubCheck";
+            string someResult = "someResult";
+            string someName = "someName";
+            string someValue = "someValue";
+
+            List<SandboxDetail> someSandboxDetails = new List<SandboxDetail> { new SandboxDetail(someName, someValue) };
+
+            var breakdown = new SandboxBreakdown(someSubCheck, someResult, someSandboxDetails);
+
+            var check = new SandboxZoomLivenessCheckBuilder()
+                .WithBreakdown(breakdown)
+                .WithRecommendation(_someRecommendation)
+                .Build();
+
+            var result = check.Result.Report.Breakdown.Single();
+
+            Assert.Equal(someName, result.Details.Single().Name);
+            Assert.Equal(someValue, result.Details.Single().Value);
+            Assert.Equal(someSubCheck, result.SubCheck);
+            Assert.Equal(someResult, result.Result);
+        }
+
+        [Fact]
+        public void ShouldBuildWithBreakdowns()
+        {
+            string someSubCheck = "someSubCheck";
+            string someResult = "someResult";
+            string someName = "someName";
+            string someValue = "someValue";
+
+            List<SandboxDetail> someSandboxDetails = new List<SandboxDetail> { new SandboxDetail(someName, someValue) };
+
+            var breakdown = new SandboxBreakdown(someSubCheck, someResult, someSandboxDetails);
+            var breakdownList = new List<SandboxBreakdown> { breakdown, breakdown };
+
+            var check = new SandboxZoomLivenessCheckBuilder()
+                .WithBreakdowns(breakdownList)
+                .WithRecommendation(_someRecommendation)
+                .Build();
+
+            Assert.Equal(2, check.Result.Report.Breakdown.Count);
+        }
+
+        [Fact]
+        public void WithBreakdownsShouldOverrideWithBreakdown()
+        {
+            var breakdownList = new List<SandboxBreakdown> { _someBreakdown, _someBreakdown };
+
+            var check = new SandboxZoomLivenessCheckBuilder()
+                .WithBreakdown(_someBreakdown)
+                .WithBreakdowns(breakdownList)
+                .WithRecommendation(_someRecommendation)
+                .Build();
+
+            Assert.Equal(2, check.Result.Report.Breakdown.Count);
+        }
+
+        [Fact]
+        public void WithBreakdownShouldAddToBreakdowns()
+        {
+            var breakdownList = new List<SandboxBreakdown> { _someBreakdown, _someBreakdown };
+
+            var check = new SandboxZoomLivenessCheckBuilder()
+                .WithBreakdowns(breakdownList)
+                .WithBreakdown(_someBreakdown)
+                .WithRecommendation(_someRecommendation)
+                .Build();
+
+            Assert.Equal(3, check.Result.Report.Breakdown.Count);
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox.Tests/HttpMock.cs
+++ b/Yoti.Auth.Sandbox.Tests/HttpMock.cs
@@ -1,0 +1,26 @@
+﻿using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Moq.Protected;
+
+namespace Yoti.Auth.Sandbox.Tests
+{
+    internal class HttpMock
+    {
+        public static Mock<HttpMessageHandler> SetupMockMessageHandler(HttpResponseMessage httpResponseMessage)
+        {
+            var handlerMock = new Mock<HttpMessageHandler>();
+            handlerMock
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>(
+                  "SendAsync",
+                  ItExpr.IsAny<HttpRequestMessage>(),
+                  ItExpr.IsAny<CancellationToken>()
+               )
+               .ReturnsAsync(httpResponseMessage)
+               .Verifiable();
+            return handlerMock;
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox.Tests/Profile/SandboxClientTests.cs
+++ b/Yoti.Auth.Sandbox.Tests/Profile/SandboxClientTests.cs
@@ -3,25 +3,22 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Moq;
-using Moq.Protected;
 using Xunit;
 using Yoti.Auth.Sandbox.Profile;
 using Yoti.Auth.Sandbox.Profile.Request;
 using Yoti.Auth.Tests.Common;
 
-namespace Yoti.Auth.Sandbox
+namespace Yoti.Auth.Sandbox.Tests.Profile
 {
-    public class YotiSandboxClientTests
+    public class DocScanSandboxClientTests
     {
         private const string _someAppId = "someAppId";
         private readonly SandboxClient _yotiSandboxClient;
         private readonly YotiTokenRequest _yotiTokenRequest;
         private static readonly Uri _someUri = new Uri("https://www.test.com");
 
-        public YotiSandboxClientTests()
+        public DocScanSandboxClientTests()
         {
             using (HttpClientHandler handler = new HttpClientHandler())
             {
@@ -106,7 +103,7 @@ namespace Yoti.Auth.Sandbox
             })
             {
                 SandboxClient yotiSandboxClient;
-                Mock<HttpMessageHandler> handlerMock = SetupMockMessageHandler(httpResponseMessage);
+                Mock<HttpMessageHandler> handlerMock = HttpMock.SetupMockMessageHandler(httpResponseMessage);
 
                 using var httpClient = new HttpClient(handlerMock.Object);
                 yotiSandboxClient = new SandboxClientBuilder(httpClient)
@@ -131,7 +128,7 @@ namespace Yoti.Auth.Sandbox
             })
             {
                 SandboxClient yotiSandboxClient;
-                Mock<HttpMessageHandler> handlerMock = SetupMockMessageHandler(httpResponseMessage);
+                Mock<HttpMessageHandler> handlerMock = HttpMock.SetupMockMessageHandler(httpResponseMessage);
 
                 using var httpClient = new HttpClient(handlerMock.Object);
                 yotiSandboxClient = new SandboxClientBuilder(httpClient)
@@ -147,21 +144,6 @@ namespace Yoti.Auth.Sandbox
 
                 Assert.Contains("Error when setting up sharing profile", exception.Message, StringComparison.Ordinal);
             };
-        }
-
-        private Mock<HttpMessageHandler> SetupMockMessageHandler(HttpResponseMessage httpResponseMessage)
-        {
-            var handlerMock = new Mock<HttpMessageHandler>();
-            handlerMock
-               .Protected()
-               .Setup<Task<HttpResponseMessage>>(
-                  "SendAsync",
-                  ItExpr.IsAny<HttpRequestMessage>(),
-                  ItExpr.IsAny<CancellationToken>()
-               )
-               .ReturnsAsync(httpResponseMessage)
-               .Verifiable();
-            return handlerMock;
         }
     }
 }

--- a/Yoti.Auth.Sandbox.Tests/Yoti.Auth.Sandbox.Tests.csproj
+++ b/Yoti.Auth.Sandbox.Tests/Yoti.Auth.Sandbox.Tests.csproj
@@ -16,16 +16,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.8.0">
+    <PackageReference Include="coverlet.msbuild" Version="2.8.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Moq" Version="4.14.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/Yoti.Auth.Sandbox/DocScan/Request/Check/Report/SandboxBreakdown.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Check/Report/SandboxBreakdown.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request.Check.Report
+{
+    public class SandboxBreakdown
+    {
+        public SandboxBreakdown(string subCheck, string result, List<SandboxDetail> details)
+        {
+            SubCheck = subCheck;
+            Result = result;
+
+            if (details == null)
+                details = new List<SandboxDetail>();
+
+            Details = details;
+        }
+
+        [JsonProperty(PropertyName = "sub_check")]
+        public string SubCheck { get; private set; }
+
+        [JsonProperty(PropertyName = "result")]
+        public string Result { get; private set; }
+
+        [JsonProperty(PropertyName = "details")]
+        public List<SandboxDetail> Details { get; private set; }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Check/Report/SandboxBreakdownBuilder.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Check/Report/SandboxBreakdownBuilder.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request.Check.Report
+{
+    public class SandboxBreakdownBuilder
+    {
+        private string _subCheck;
+        private string _result;
+        private readonly List<SandboxDetail> _details = new List<SandboxDetail>();
+
+        public SandboxBreakdownBuilder WithSubCheck(string subCheck)
+        {
+            _subCheck = subCheck;
+            return this;
+        }
+
+        public SandboxBreakdownBuilder WithResult(string result)
+        {
+            _result = result;
+            return this;
+        }
+
+        public SandboxBreakdownBuilder WithDetail(SandboxDetail detail)
+        {
+            _details.Add(detail);
+            return this;
+        }
+
+        public SandboxBreakdown Build()
+        {
+            Validation.NotNullOrEmpty(_subCheck, nameof(_subCheck));
+            Validation.NotNullOrEmpty(_result, nameof(_result));
+
+            return new SandboxBreakdown(_subCheck, _result, _details);
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Check/Report/SandboxDetail.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Check/Report/SandboxDetail.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request.Check.Report
+{
+    public class SandboxDetail
+    {
+        public SandboxDetail(string name, string value)
+        {
+            Name = name;
+            Value = value;
+        }
+
+        [JsonProperty(PropertyName = "name")]
+        public string Name { get; private set; }
+
+        [JsonProperty(PropertyName = "value")]
+        public string Value { get; private set; }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Check/Report/SandboxRecommendation.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Check/Report/SandboxRecommendation.cs
@@ -1,0 +1,23 @@
+﻿using Newtonsoft.Json;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request.Check.Report
+{
+    public class SandboxRecommendation
+    {
+        public SandboxRecommendation(string value, string reason, string recoverySuggestion)
+        {
+            Value = value;
+            Reason = reason;
+            RecoverySuggestion = recoverySuggestion;
+        }
+
+        [JsonProperty(PropertyName = "value")]
+        public string Value { get; }
+
+        [JsonProperty(PropertyName = "reason")]
+        public string Reason { get; }
+
+        [JsonProperty(PropertyName = "recovery_suggestion")]
+        public string RecoverySuggestion { get; }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Check/Report/SandboxRecommendationBuilder.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Check/Report/SandboxRecommendationBuilder.cs
@@ -1,0 +1,34 @@
+﻿namespace Yoti.Auth.Sandbox.DocScan.Request.Check.Report
+{
+    public class SandboxRecommendationBuilder
+    {
+        private string _value;
+        private string _reason;
+        private string _recoverySuggestion;
+
+        public SandboxRecommendationBuilder WithValue(string value)
+        {
+            _value = value;
+            return this;
+        }
+
+        public SandboxRecommendationBuilder WithReason(string reason)
+        {
+            _reason = reason;
+            return this;
+        }
+
+        public SandboxRecommendationBuilder WithRecoverySuggestion(string recoverySuggestion)
+        {
+            _recoverySuggestion = recoverySuggestion;
+            return this;
+        }
+
+        public SandboxRecommendation Build()
+        {
+            Validation.NotNull(_value, nameof(_value));
+
+            return new SandboxRecommendation(_value, _reason, _recoverySuggestion);
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxCheck.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxCheck.cs
@@ -1,0 +1,15 @@
+﻿using Newtonsoft.Json;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request.Check
+{
+    public class SandboxCheck
+    {
+        public SandboxCheck(SandboxCheckResult result)
+        {
+            Result = result;
+        }
+
+        [JsonProperty(PropertyName = "result")]
+        public virtual SandboxCheckResult Result { get; }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxCheckBuilder.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxCheckBuilder.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using Yoti.Auth.Sandbox.DocScan.Request.Check.Report;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request.Check
+{
+    public abstract class SandboxCheckBuilder<TBuilder, TCheck>
+        where TBuilder : SandboxCheckBuilder<TBuilder, TCheck>
+        where TCheck : SandboxCheck
+    {
+        protected SandboxRecommendation Recommendation { get; private set; }
+        protected List<SandboxBreakdown> Breakdown { get; private set; } = new List<SandboxBreakdown>();
+
+        public TBuilder WithRecommendation(SandboxRecommendation recommendation)
+        {
+            Recommendation = recommendation;
+            return (TBuilder)this;
+        }
+
+        public TBuilder WithBreakdown(SandboxBreakdown breakdown)
+        {
+            Breakdown.Add(breakdown);
+            return (TBuilder)this;
+        }
+
+        public TBuilder WithBreakdowns(List<SandboxBreakdown> breakdowns)
+        {
+            Breakdown = breakdowns;
+            return (TBuilder)this;
+        }
+
+        public abstract TCheck Build();
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxCheckReport.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxCheckReport.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+using Yoti.Auth.Sandbox.DocScan.Request.Check.Report;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request.Check
+{
+    public class SandboxCheckReport
+    {
+        public SandboxCheckReport(SandboxRecommendation recommendation, List<SandboxBreakdown> breakdown)
+        {
+            Recommendation = recommendation;
+            Breakdown = breakdown;
+        }
+
+        [JsonProperty(PropertyName = "recommendation")]
+        public SandboxRecommendation Recommendation { get; }
+
+        [JsonProperty(PropertyName = "breakdown")]
+        public List<SandboxBreakdown> Breakdown { get; }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxCheckResult.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxCheckResult.cs
@@ -1,0 +1,15 @@
+﻿using Newtonsoft.Json;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request.Check
+{
+    public class SandboxCheckResult
+    {
+        public SandboxCheckResult(SandboxCheckReport report)
+        {
+            Report = report;
+        }
+
+        [JsonProperty(PropertyName = "report")]
+        public SandboxCheckReport Report { get; }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxDocumentAuthenticityCheck.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxDocumentAuthenticityCheck.cs
@@ -1,0 +1,12 @@
+﻿using Yoti.Auth.Sandbox.DocScan.Request.Task;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request.Check
+{
+    public class SandboxDocumentAuthenticityCheck : SandboxDocumentCheck
+    {
+        public SandboxDocumentAuthenticityCheck(SandboxCheckResult result, SandboxDocumentFilter documentFilter)
+            : base(result, documentFilter)
+        {
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxDocumentAuthenticityCheckBuilder.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxDocumentAuthenticityCheckBuilder.cs
@@ -1,0 +1,16 @@
+﻿namespace Yoti.Auth.Sandbox.DocScan.Request.Check
+{
+    public class SandboxDocumentAuthenticityCheckBuilder
+        : SandboxDocumentCheckBuilder<SandboxDocumentAuthenticityCheckBuilder, SandboxDocumentAuthenticityCheck>
+    {
+        public override SandboxDocumentAuthenticityCheck Build()
+        {
+            Validation.NotNull(Recommendation, nameof(Recommendation));
+
+            SandboxCheckReport report = new SandboxCheckReport(Recommendation, Breakdown);
+            SandboxCheckResult result = new SandboxCheckResult(report);
+
+            return new SandboxDocumentAuthenticityCheck(result, DocumentFilter);
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxDocumentCheck.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxDocumentCheck.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+using Yoti.Auth.Sandbox.DocScan.Request.Task;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request.Check
+{
+    public class SandboxDocumentCheck : SandboxCheck
+    {
+        [JsonProperty(PropertyName = "document_filter")]
+        public SandboxDocumentFilter DocumentFilter { get; }
+
+        public SandboxDocumentCheck(SandboxCheckResult result)
+            : base(result)
+        {
+        }
+
+        public SandboxDocumentCheck(SandboxCheckResult result, SandboxDocumentFilter documentFilter)
+            : base(result)
+        {
+            DocumentFilter = documentFilter;
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxDocumentCheckBuilder.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxDocumentCheckBuilder.cs
@@ -1,0 +1,18 @@
+﻿using Yoti.Auth.Sandbox.DocScan.Request.Task;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request.Check
+{
+    public abstract class SandboxDocumentCheckBuilder<TBuilder, TCheck>
+        : SandboxCheckBuilder<TBuilder, TCheck>
+        where TBuilder : SandboxDocumentCheckBuilder<TBuilder, TCheck>
+        where TCheck : SandboxDocumentCheck
+    {
+        public SandboxDocumentFilter DocumentFilter { get; private set; }
+
+        public TBuilder WithDocumentFilter(SandboxDocumentFilter documentFilter)
+        {
+            DocumentFilter = documentFilter;
+            return (TBuilder)this;
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxDocumentFaceMatchCheck.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxDocumentFaceMatchCheck.cs
@@ -1,0 +1,17 @@
+﻿using Yoti.Auth.Sandbox.DocScan.Request.Task;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request.Check
+{
+    public class SandboxDocumentFaceMatchCheck : SandboxDocumentCheck
+    {
+        public SandboxDocumentFaceMatchCheck(SandboxCheckResult result)
+          : base(result)
+        {
+        }
+
+        public SandboxDocumentFaceMatchCheck(SandboxCheckResult result, SandboxDocumentFilter documentFilter)
+            : base(result, documentFilter)
+        {
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxDocumentFaceMatchCheckBuilder.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxDocumentFaceMatchCheckBuilder.cs
@@ -1,0 +1,16 @@
+﻿namespace Yoti.Auth.Sandbox.DocScan.Request.Check
+{
+    public class SandboxDocumentFaceMatchCheckBuilder
+        : SandboxDocumentCheckBuilder<SandboxDocumentFaceMatchCheckBuilder, SandboxDocumentFaceMatchCheck>
+    {
+        public override SandboxDocumentFaceMatchCheck Build()
+        {
+            Validation.NotNull(Recommendation, nameof(Recommendation));
+
+            SandboxCheckReport report = new SandboxCheckReport(Recommendation, Breakdown);
+            SandboxCheckResult result = new SandboxCheckResult(report);
+
+            return new SandboxDocumentFaceMatchCheck(result, DocumentFilter);
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxDocumentTextDataCheck.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxDocumentTextDataCheck.cs
@@ -1,0 +1,17 @@
+﻿using Yoti.Auth.Sandbox.DocScan.Request.Task;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request.Check
+{
+    public class SandboxDocumentTextDataCheck : SandboxDocumentCheck
+    {
+        public SandboxDocumentTextDataCheck(SandboxDocumentTextDataCheckResult result)
+            : base(result)
+        {
+        }
+
+        public SandboxDocumentTextDataCheck(SandboxDocumentTextDataCheckResult result, SandboxDocumentFilter documentFilter)
+            : base(result, documentFilter)
+        {
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxDocumentTextDataCheckBuilder.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxDocumentTextDataCheckBuilder.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request.Check
+{
+    public class SandboxDocumentTextDataCheckBuilder
+        : SandboxDocumentCheckBuilder<SandboxDocumentTextDataCheckBuilder, SandboxDocumentTextDataCheck>
+    {
+        private Dictionary<string, object> _documentFields = new Dictionary<string, object>();
+
+        public SandboxDocumentTextDataCheckBuilder WithDocumentField(string key, object value)
+        {
+            _documentFields.Add(key, value);
+            return this;
+        }
+
+        public SandboxDocumentTextDataCheckBuilder WithDocumentFields(Dictionary<string, object> documentFields)
+        {
+            _documentFields = documentFields;
+            return this;
+        }
+
+        public override SandboxDocumentTextDataCheck Build()
+        {
+            Validation.NotNull(Recommendation, nameof(Recommendation));
+
+            SandboxCheckReport report = new SandboxCheckReport(Recommendation, Breakdown);
+            SandboxDocumentTextDataCheckResult result = new SandboxDocumentTextDataCheckResult(report, _documentFields);
+
+            return new SandboxDocumentTextDataCheck(result, DocumentFilter);
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxDocumentTextDataCheckResult.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxDocumentTextDataCheckResult.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request.Check
+{
+    public class SandboxDocumentTextDataCheckResult : SandboxCheckResult
+    {
+        [JsonProperty(PropertyName = "document_fields")]
+        public Dictionary<string, object> DocumentFields { get; internal set; }
+
+        public SandboxDocumentTextDataCheckResult(SandboxCheckReport report)
+            : base(report)
+        {
+        }
+
+        public SandboxDocumentTextDataCheckResult(SandboxCheckReport report, Dictionary<string, object> documentFields)
+             : base(report)
+        {
+            DocumentFields = documentFields;
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxLivenessCheck.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxLivenessCheck.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request.Check
+{
+    public class SandboxLivenessCheck : SandboxCheck
+    {
+        public SandboxLivenessCheck(SandboxCheckResult result, string livenessType)
+            : base(result)
+        {
+            LivenessType = livenessType;
+        }
+
+        [JsonProperty(PropertyName = "liveness_type")]
+        public string LivenessType { get; set; }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxZoomLivenessCheckBuilder.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxZoomLivenessCheckBuilder.cs
@@ -1,0 +1,16 @@
+﻿namespace Yoti.Auth.Sandbox.DocScan.Request.Check
+{
+    public class SandboxZoomLivenessCheckBuilder
+        : SandboxCheckBuilder<SandboxZoomLivenessCheckBuilder, SandboxLivenessCheck>
+    {
+        public override SandboxLivenessCheck Build()
+        {
+            Validation.NotNull(Recommendation, nameof(Recommendation));
+
+            SandboxCheckReport report = new SandboxCheckReport(Recommendation, Breakdown);
+            SandboxCheckResult result = new SandboxCheckResult(report);
+
+            return new SandboxLivenessCheck(result, Constants.DocScanConstants.Zoom);
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Resource/Document/DocumentResource.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Resource/Document/DocumentResource.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request.Resource.Document
+{
+    public class DocumentResource : SandboxPayload
+    {
+        [JsonProperty(PropertyName = "document_type")]
+        public string DocumentType { get; }
+
+        [JsonProperty(PropertyName = "issuing_country")]
+        public string IssuingCountry { get; }
+
+        public DocumentResource(string documentType, string issuingCountry)
+        {
+            DocumentType = documentType;
+            IssuingCountry = issuingCountry;
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Resource/Document/DocumentResourceBuilder.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Resource/Document/DocumentResourceBuilder.cs
@@ -1,0 +1,28 @@
+﻿namespace Yoti.Auth.Sandbox.DocScan.Request.Resource.Document
+{
+    public class DocumentResourceBuilder
+    {
+        private string _documentType;
+        private string _issuingCountry;
+
+        public DocumentResourceBuilder WithDocumentType(string documentType)
+        {
+            _documentType = documentType;
+            return this;
+        }
+
+        public DocumentResourceBuilder WithIssuingCountry(string issuingCountry)
+        {
+            _issuingCountry = issuingCountry;
+            return this;
+        }
+
+        public DocumentResource Build()
+        {
+            Validation.NotNullOrEmpty(_documentType, nameof(_documentType));
+            Validation.NotNullOrEmpty(_issuingCountry, nameof(_issuingCountry));
+
+            return new DocumentResource(_documentType, _issuingCountry);
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Resource/Extraction/TextExtractionResource.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Resource/Extraction/TextExtractionResource.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request.Resource.Extraction
+{
+    public class TextExtractionResource : SandboxPayload
+    {
+        public TextExtractionResource(string clientExtractionOutcome, Dictionary<string, object> documentFields)
+        {
+            ClientExtractionOutcome = clientExtractionOutcome;
+            DocumentFields = documentFields;
+        }
+
+        [JsonProperty(PropertyName = "client_extraction_outcome")]
+        public string ClientExtractionOutcome { get; }
+
+        [JsonProperty(PropertyName = "document_fields")]
+        public Dictionary<string, object> DocumentFields { get; }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Resource/Extraction/TextExtractionResourceBuilder.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Resource/Extraction/TextExtractionResourceBuilder.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request.Resource.Extraction
+{
+    public class TextExtractionResourceBuilder
+    {
+        private string _clientExtractionOutcome;
+        private Dictionary<string, object> _documentFields = new Dictionary<string, object>();
+
+        public TextExtractionResourceBuilder WithClientExtractionOutcome(string clientExtractionOutcome)
+        {
+            _clientExtractionOutcome = clientExtractionOutcome;
+            return this;
+        }
+
+        public TextExtractionResourceBuilder WithDocumentField(string key, object value)
+        {
+            _documentFields.Add(key, value);
+            return this;
+        }
+
+        public TextExtractionResourceBuilder WithDocumentFields(Dictionary<string, object> documentFields)
+        {
+            _documentFields = documentFields;
+            return this;
+        }
+
+        public TextExtractionResource Build()
+        {
+            Validation.NotNull(_clientExtractionOutcome, nameof(_clientExtractionOutcome));
+            Validation.NotNull(_documentFields, nameof(_documentFields));
+
+            return new TextExtractionResource(_clientExtractionOutcome, _documentFields);
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Resource/Liveness/FaceMap.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Resource/Liveness/FaceMap.cs
@@ -1,0 +1,12 @@
+﻿using System.Net.Http.Headers;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request.Resource.Liveness
+{
+    public class FaceMap : SandboxMedia
+    {
+        public FaceMap(MediaTypeHeaderValue mediaType, byte[] binaryContent)
+            : base(mediaType, binaryContent)
+        {
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Resource/Liveness/ZoomFrame.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Resource/Liveness/ZoomFrame.cs
@@ -1,0 +1,12 @@
+﻿using System.Net.Http.Headers;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request.Resource.Liveness
+{
+    public class ZoomFrame : SandboxMedia
+    {
+        public ZoomFrame(MediaTypeHeaderValue mediaType, byte[] binaryContent)
+            : base(mediaType, binaryContent)
+        {
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Resource/Liveness/ZoomLivenessResource.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Resource/Liveness/ZoomLivenessResource.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request.Resource.Liveness
+{
+    public class ZoomLivenessResource : SandboxPayload
+    {
+        [JsonProperty(PropertyName = "source")]
+        public string Source { get; }
+
+        public ZoomLivenessResource(string source)
+        {
+            Source = source;
+        }
+
+        public static ZoomLivenessResource ForWeb()
+        {
+            return new ZoomLivenessResource("WEB");
+        }
+
+        public static ZoomLivenessResource ForNative()
+        {
+            return new ZoomLivenessResource("NATIVE");
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Resource/Liveness/ZoomLivenessResourceBuilder.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Resource/Liveness/ZoomLivenessResourceBuilder.cs
@@ -1,0 +1,20 @@
+﻿namespace Yoti.Auth.Sandbox.DocScan.Request.Resource.Liveness
+{
+    public class ZoomLivenessResourceBuilder
+    {
+        private string _source;
+
+        public ZoomLivenessResourceBuilder WithSource(string source)
+        {
+            _source = source;
+            return this;
+        }
+
+        public ZoomLivenessResource Build()
+        {
+            Validation.NotNullOrEmpty(_source, nameof(_source));
+
+            return new ZoomLivenessResource(_source);
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/ResponseConfig.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/ResponseConfig.cs
@@ -1,0 +1,20 @@
+﻿using Newtonsoft.Json;
+using Yoti.Auth.Sandbox.DocScan.Request.Task;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request
+{
+    public class ResponseConfig
+    {
+        public ResponseConfig(SandboxTaskResults taskResults, SandboxCheckReports sandboxCheckReports)
+        {
+            TaskResults = taskResults;
+            SandboxCheckReports = sandboxCheckReports;
+        }
+
+        [JsonProperty(PropertyName = "task_results")]
+        public SandboxTaskResults TaskResults { get; }
+
+        [JsonProperty(PropertyName = "check_reports")]
+        public SandboxCheckReports SandboxCheckReports { get; }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/ResponseConfigBuilder.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/ResponseConfigBuilder.cs
@@ -1,0 +1,27 @@
+﻿using Yoti.Auth.Sandbox.DocScan.Request.Task;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request
+{
+    public class ResponseConfigBuilder
+    {
+        private SandboxTaskResults _taskResults;
+        private SandboxCheckReports _sandboxCheckReports;
+
+        public ResponseConfigBuilder WithTaskResults(SandboxTaskResults taskContainer)
+        {
+            _taskResults = taskContainer;
+            return this;
+        }
+
+        public ResponseConfigBuilder WithCheckReports(SandboxCheckReports sandboxCheckReports)
+        {
+            _sandboxCheckReports = sandboxCheckReports;
+            return this;
+        }
+
+        public ResponseConfig Build()
+        {
+            return new ResponseConfig(_taskResults, _sandboxCheckReports);
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/SandboxCheckReports.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/SandboxCheckReports.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+using Yoti.Auth.Constants;
+using Yoti.Auth.Sandbox.DocScan.Request.Check;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request
+{
+    public class SandboxCheckReports
+    {
+        public SandboxCheckReports(
+            List<SandboxDocumentTextDataCheck> textDataChecks,
+            List<SandboxDocumentAuthenticityCheck> documentAuthenticityChecks,
+            List<SandboxLivenessCheck> livenessChecks,
+            List<SandboxDocumentFaceMatchCheck> documentFaceMatchChecks,
+            int? asyncReportDelay)
+        {
+            TextDataCheck = textDataChecks;
+            DocumentAuthenticityCheck = documentAuthenticityChecks;
+            LivenessChecks = livenessChecks;
+            DocumentFaceMatchCheck = documentFaceMatchChecks;
+            AsyncReportDelay = asyncReportDelay;
+        }
+
+        [JsonProperty(PropertyName = DocScanConstants.IdDocumentTextDataCheck)]
+        public List<SandboxDocumentTextDataCheck> TextDataCheck { get; }
+
+        [JsonProperty(PropertyName = DocScanConstants.IdDocumentAuthenticity)]
+        public List<SandboxDocumentAuthenticityCheck> DocumentAuthenticityCheck { get; }
+
+        [JsonProperty(PropertyName = DocScanConstants.Liveness)]
+        public List<SandboxLivenessCheck> LivenessChecks { get; }
+
+        [JsonProperty(PropertyName = DocScanConstants.IdDocumentFaceMatch)]
+        public List<SandboxDocumentFaceMatchCheck> DocumentFaceMatchCheck { get; }
+
+        [JsonProperty(PropertyName = "async_report_delay")]
+        public int? AsyncReportDelay { get; }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/SandboxCheckReportsBuilder.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/SandboxCheckReportsBuilder.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+using Yoti.Auth.Sandbox.DocScan.Request.Check;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request
+{
+    public class SandboxCheckReportsBuilder
+    {
+        private readonly List<SandboxDocumentTextDataCheck> _textDataChecks;
+        private readonly List<SandboxDocumentAuthenticityCheck> _documentAuthenticityChecks;
+        private readonly List<SandboxLivenessCheck> _livenessChecks;
+        private readonly List<SandboxDocumentFaceMatchCheck> _documentFaceMatchChecks;
+        private int? _asyncReportDelay;
+
+        public SandboxCheckReportsBuilder()
+
+        {
+            _textDataChecks = new List<SandboxDocumentTextDataCheck>();
+            _documentAuthenticityChecks = new List<SandboxDocumentAuthenticityCheck>();
+            _livenessChecks = new List<SandboxLivenessCheck>();
+            _documentFaceMatchChecks = new List<SandboxDocumentFaceMatchCheck>();
+        }
+
+        public SandboxCheckReportsBuilder WithDocumentTextDataCheck(SandboxDocumentTextDataCheck textDataCheckReport)
+        {
+            _textDataChecks.Add(textDataCheckReport);
+            return this;
+        }
+
+        public SandboxCheckReportsBuilder WithDocumentAuthenticityCheck(SandboxDocumentAuthenticityCheck documentAuthenticityReport)
+        {
+            _documentAuthenticityChecks.Add(documentAuthenticityReport);
+            return this;
+        }
+
+        public SandboxCheckReportsBuilder WithLivenessCheck(SandboxLivenessCheck livenessReport)
+        {
+            _livenessChecks.Add(livenessReport);
+            return this;
+        }
+
+        public SandboxCheckReportsBuilder WithDocumentFaceMatchCheck(SandboxDocumentFaceMatchCheck documentFaceMatchReport)
+        {
+            _documentFaceMatchChecks.Add(documentFaceMatchReport);
+            return this;
+        }
+
+        public SandboxCheckReportsBuilder WithAsyncReportDelay(int asyncReportDelay)
+        {
+            _asyncReportDelay = asyncReportDelay;
+            return this;
+        }
+
+        public SandboxCheckReports Build()
+        {
+            return new SandboxCheckReports(_textDataChecks, _documentAuthenticityChecks, _livenessChecks, _documentFaceMatchChecks, _asyncReportDelay);
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/SandboxClient.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/SandboxClient.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Net.Http;
+using System.Text;
+using Newtonsoft.Json;
+using Org.BouncyCastle.Crypto;
+using Yoti.Auth.Web;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request
+{
+    public class SandboxClient
+    {
+        private const string _yotiDocScanSandboxPathPrefix = "sandbox/idverify/v1";
+        private readonly Uri _defaultDocScanSandboxApiUrl = new Uri(Constants.Api.DefaultYotiHost + _yotiDocScanSandboxPathPrefix);
+
+        private readonly HttpClient _httpClient;
+        private readonly Uri _docScanSandboxApiUrl;
+        private readonly string _sdkId;
+        private readonly AsymmetricCipherKeyPair _keyPair;
+
+        public static SandboxClientBuilder Builder(HttpClient httpClient = null)
+        {
+            return new SandboxClientBuilder(httpClient);
+        }
+
+        internal SandboxClient(string sdkId, AsymmetricCipherKeyPair keyPair, Uri apiUri = null, HttpClient httpClient = null)
+        {
+            _httpClient = httpClient ?? new HttpClient();
+            _docScanSandboxApiUrl = apiUri ?? _defaultDocScanSandboxApiUrl;
+            _sdkId = sdkId;
+            _keyPair = keyPair;
+        }
+
+        public void ConfigureSessionResponse(string sessionId, ResponseConfig sandboxExpection)
+        {
+            try
+            {
+                string serializedSandboxResponseConfig = JsonConvert.SerializeObject(
+                    sandboxExpection,
+                    new JsonSerializerSettings
+                    {
+                        NullValueHandling = NullValueHandling.Ignore
+                    });
+                byte[] body = Encoding.UTF8.GetBytes(serializedSandboxResponseConfig);
+
+                Yoti.Auth.Web.Request request = new RequestBuilder()
+                    .WithKeyPair(_keyPair)
+                    .WithBaseUri(_docScanSandboxApiUrl)
+                    .WithEndpoint($"/sessions/{sessionId}/response-config")
+                    .WithHttpMethod(HttpMethod.Put)
+                    .WithContent(body)
+                    .WithQueryParam("sdkId", _sdkId)
+                    .Build();
+
+                HttpResponseMessage response = request.Execute(_httpClient).Result;
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    Response.CreateYotiExceptionFromStatusCode<SandboxException>(response);
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new SandboxException(Properties.Resources.DocScanSessionResponseError, ex);
+            }
+        }
+
+        public void ConfigureApplicationResponse(ResponseConfig sandboxExpection)
+        {
+            try
+            {
+                string serializedSandboxResponseConfig = JsonConvert.SerializeObject(
+                   sandboxExpection,
+                   new JsonSerializerSettings
+                   {
+                       NullValueHandling = NullValueHandling.Ignore
+                   });
+                byte[] body = Encoding.UTF8.GetBytes(serializedSandboxResponseConfig);
+
+                Yoti.Auth.Web.Request request = new RequestBuilder()
+                    .WithKeyPair(_keyPair)
+                    .WithBaseUri(_docScanSandboxApiUrl)
+                    .WithEndpoint($"/apps/{_sdkId}/response-config")
+                    .WithHttpMethod(HttpMethod.Put)
+                    .WithContent(body)
+                    .Build();
+
+                HttpResponseMessage response = request.Execute(_httpClient).Result;
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    Response.CreateYotiExceptionFromStatusCode<SandboxException>(response);
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new SandboxException(Properties.Resources.DocScanApplicationResponseError, ex);
+            }
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/SandboxClientBuilder.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/SandboxClientBuilder.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Net.Http;
 using Org.BouncyCastle.Crypto;
 
-namespace Yoti.Auth.Sandbox.Profile
+namespace Yoti.Auth.Sandbox.DocScan.Request
 {
     public class SandboxClientBuilder
     {

--- a/Yoti.Auth.Sandbox/DocScan/Request/SandboxMedia.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/SandboxMedia.cs
@@ -1,0 +1,27 @@
+﻿using System.Net.Http.Headers;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request.Resource
+{
+    public class SandboxMedia
+    {
+        public SandboxMedia(MediaTypeHeaderValue mediaType, byte[] binaryContent) : base()
+        {
+            MediaType = mediaType;
+            SetBinaryContent(binaryContent);
+        }
+
+        public MediaTypeHeaderValue MediaType { get; }
+
+        private byte[] _binaryContent;
+
+        public byte[] GetBinaryContent()
+        {
+            return _binaryContent;
+        }
+
+        public void SetBinaryContent(byte[] value)
+        {
+            _binaryContent = value;
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/SandboxPayload.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/SandboxPayload.cs
@@ -1,0 +1,6 @@
+﻿namespace Yoti.Auth.Sandbox.DocScan.Request.Resource
+{
+    public class SandboxPayload
+    {
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentFilter.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentFilter.cs
@@ -1,0 +1,6 @@
+﻿namespace Yoti.Auth.Sandbox.DocScan.Request.Task
+{
+    public class SandboxDocumentFilter
+    {
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentTextDataExtractionTask.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentTextDataExtractionTask.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request.Task
+{
+    public class SandboxDocumentTextDataExtractionTask : SandboxTaskResult
+    {
+        public SandboxDocumentTextDataExtractionTask(SandboxDocumentTextDataExtractionTaskResult result, SandboxDocumentFilter documentFilter)
+        {
+            Result = result;
+            DocumentFilter = documentFilter;
+        }
+
+        [JsonProperty(PropertyName = "result")]
+        public SandboxDocumentTextDataExtractionTaskResult Result { get; }
+
+        [JsonProperty(PropertyName = "document_filter")]
+        public SandboxDocumentFilter DocumentFilter { get; }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentTextDataExtractionTaskBuilder.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentTextDataExtractionTaskBuilder.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request.Task
+{
+    public class SandboxDocumentTextDataExtractionTaskBuilder : SandboxTaskResult
+    {
+        private Dictionary<string, object> _documentFields = new Dictionary<string, object>();
+        private SandboxDocumentFilter _documentFilter;
+
+        public SandboxDocumentTextDataExtractionTaskBuilder WithDocumentField(string key, object value)
+        {
+            _documentFields.Add(key, value);
+            return this;
+        }
+
+        public SandboxDocumentTextDataExtractionTaskBuilder WithDocumentFields(Dictionary<string, object> documentFields)
+        {
+            _documentFields = documentFields;
+            return this;
+        }
+
+        public SandboxDocumentTextDataExtractionTaskBuilder WithDocumentFilter(SandboxDocumentFilter documentFilter)
+        {
+            _documentFilter = documentFilter;
+            return this;
+        }
+
+        public SandboxDocumentTextDataExtractionTask Build()
+        {
+            SandboxDocumentTextDataExtractionTaskResult result = new SandboxDocumentTextDataExtractionTaskResult(_documentFields);
+            return new SandboxDocumentTextDataExtractionTask(result, _documentFilter);
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentTextDataExtractionTaskResult.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentTextDataExtractionTaskResult.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request.Task
+{
+    public class SandboxDocumentTextDataExtractionTaskResult
+    {
+        [JsonProperty(PropertyName = "document_fields")]
+        public Dictionary<string, object> DocumentFields { get; }
+
+        public SandboxDocumentTextDataExtractionTaskResult(Dictionary<string, object> documentFields)
+        {
+            DocumentFields = documentFields;
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxTaskResult.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxTaskResult.cs
@@ -1,0 +1,6 @@
+﻿namespace Yoti.Auth.Sandbox.DocScan.Request.Task
+{
+    public class SandboxTaskResult
+    {
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxTaskResults.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxTaskResults.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request.Task
+{
+    public class SandboxTaskResults
+    {
+        [JsonProperty(PropertyName = Constants.DocScanConstants.IdDocumentTextDataExtraction)]
+        public List<SandboxDocumentTextDataExtractionTask> TextDataExtractionTasks { get; }
+
+        public SandboxTaskResults(List<SandboxDocumentTextDataExtractionTask> textDataExtractionTasks)
+        {
+            TextDataExtractionTasks = textDataExtractionTasks;
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxTaskResultsBuilder.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxTaskResultsBuilder.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request.Task
+{
+    public class SandboxTaskResultsBuilder
+    {
+        private readonly List<SandboxDocumentTextDataExtractionTask> _documentTextDataExtractionTasks = new List<SandboxDocumentTextDataExtractionTask>();
+
+        public SandboxTaskResultsBuilder WithDocumentTextDataExtractionTask(SandboxDocumentTextDataExtractionTask textDataExtractionTask)
+        {
+            _documentTextDataExtractionTasks.Add(textDataExtractionTask);
+            return this;
+        }
+
+        public SandboxTaskResults Build()
+        {
+            return new SandboxTaskResults(_documentTextDataExtractionTasks);
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox/Profile/Request/Attribute/Derivation/SandboxAgeVerificationBuilder.cs
+++ b/Yoti.Auth.Sandbox/Profile/Request/Attribute/Derivation/SandboxAgeVerificationBuilder.cs
@@ -56,6 +56,7 @@ namespace Yoti.Auth.Sandbox.Profile.Request.Attribute.Derivation
         public SandboxAgeVerificationBuilder WithAnchors(List<SandboxAnchor> anchors)
         {
             Validation.NotNull(anchors, nameof(anchors));
+            Validation.CollectionNotEmpty(anchors, nameof(anchors));
             _anchors = anchors;
             return this;
         }

--- a/Yoti.Auth.Sandbox/Properties/Resources.Designer.cs
+++ b/Yoti.Auth.Sandbox/Properties/Resources.Designer.cs
@@ -61,6 +61,33 @@ namespace Yoti.Auth.Sandbox.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error when setting up Doc Scan application response.
+        /// </summary>
+        internal static string DocScanApplicationResponseError {
+            get {
+                return ResourceManager.GetString("DocScanApplicationResponseError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error when setting up Doc Scan session response.
+        /// </summary>
+        internal static string DocScanSessionResponseError {
+            get {
+                return ResourceManager.GetString("DocScanSessionResponseError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error setting response config. for session.
+        /// </summary>
+        internal static string SessionResponseConfigError {
+            get {
+                return ResourceManager.GetString("SessionResponseConfigError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Error when setting up sharing profile.
         /// </summary>
         internal static string SharingProfileError {

--- a/Yoti.Auth.Sandbox/Properties/Resources.resx
+++ b/Yoti.Auth.Sandbox/Properties/Resources.resx
@@ -117,6 +117,15 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="DocScanApplicationResponseError" xml:space="preserve">
+    <value>Error when setting up Doc Scan application response</value>
+  </data>
+  <data name="DocScanSessionResponseError" xml:space="preserve">
+    <value>Error when setting up Doc Scan session response</value>
+  </data>
+  <data name="SessionResponseConfigError" xml:space="preserve">
+    <value>Error setting response config. for session</value>
+  </data>
   <data name="SharingProfileError" xml:space="preserve">
     <value>Error when setting up sharing profile</value>
   </data>

--- a/Yoti.Auth.Sandbox/SandboxException.cs
+++ b/Yoti.Auth.Sandbox/SandboxException.cs
@@ -1,10 +1,9 @@
 ﻿using System;
-using System.Runtime.Serialization;
+using Yoti.Auth.Exceptions;
 
 namespace Yoti.Auth.Sandbox
 {
-    [Serializable]
-    public class SandboxException : Exception
+    public class SandboxException : YotiException
     {
         public SandboxException()
         {
@@ -17,11 +16,6 @@ namespace Yoti.Auth.Sandbox
 
         public SandboxException(string message, Exception innerException)
             : base(message, innerException)
-        {
-        }
-
-        protected SandboxException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
         {
         }
     }

--- a/Yoti.Auth.Sandbox/Yoti.Auth.Sandbox.csproj
+++ b/Yoti.Auth.Sandbox/Yoti.Auth.Sandbox.csproj
@@ -22,11 +22,32 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>$(MSBuildProjectName).Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Yoti" Version="3.3.1" />
+    <PackageReference Include="Yoti" Version="3.5.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="Properties\Resources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="Properties\Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Added
- Validation that anchors passed to WithAnchors is not an empty collection (use null instead)
- Doc Scan Sandbox support

See  [Examples/Yoti.Auth.Sandbox.Examples](https://github.com/getyoti/yoti-dotnet-sdk-sandbox/tree/SDK-1298-DocScan/Examples/Yoti.Auth.Sandbox.Examples) for examples