### PR TITLE
SDK-1516: Mark Optional as obsolete/deprecated

### DIFF
--- a/Yoti.Auth.Sandbox.Tests/Yoti.Auth.Sandbox.Tests.csproj
+++ b/Yoti.Auth.Sandbox.Tests/Yoti.Auth.Sandbox.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors />
   </PropertyGroup>
 

--- a/Yoti.Auth.Sandbox/Profile/Request/Attribute/SandboxAttribute.cs
+++ b/Yoti.Auth.Sandbox/Profile/Request/Attribute/SandboxAttribute.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Yoti.Auth.Sandbox.Profile.Request.Attribute
@@ -27,6 +28,7 @@ namespace Yoti.Auth.Sandbox.Profile.Request.Attribute
         [JsonProperty(PropertyName = "derivation")]
         public string Derivation { get; }
 
+        [Obsolete("Deprecated, will be removed in v2.0.0")]
         [JsonProperty(PropertyName = "optional")]
         public string Optional { get; }
 

--- a/Yoti.Auth.Sandbox/Profile/Request/Attribute/SandboxAttributeBuilder.cs
+++ b/Yoti.Auth.Sandbox/Profile/Request/Attribute/SandboxAttributeBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Yoti.Auth.Sandbox.Profile.Request.Attribute
 {
@@ -28,6 +29,7 @@ namespace Yoti.Auth.Sandbox.Profile.Request.Attribute
             return this;
         }
 
+        [Obsolete("Deprecated, will be removed in v2.0.0")]
         public SandboxAttributeBuilder WithOptional(bool optional)
         {
             _optional = optional;

--- a/Yoti.Auth.Sandbox/Yoti.Auth.Sandbox.csproj
+++ b/Yoti.Auth.Sandbox/Yoti.Auth.Sandbox.csproj
@@ -12,7 +12,7 @@
     <PackageId>Yoti.Sandbox</PackageId>
     <PackageProjectUrl>https://developers.yoti.com/yoti-app/web-integration</PackageProjectUrl>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ steps:
     scannerMode: 'MSBuild'
     projectKey: 'getyoti:dotnet-sandbox'
     projectName: '.NET SDK Sandbox'
-    projectVersion: '1.2.0'
+    projectVersion: '1.3.0'
     extraProperties: |
       sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml"
       sonar.links.scm = https://github.com/getyoti/yoti-dotnet-sdk-sandbox


### PR DESCRIPTION
- Mark Optional as obsolete/deprecated
- Don't treat warnings as errors in Tests