### PR TITLE
SDK-1763: Exclude document fields when not set

### DIFF
--- a/Yoti.Auth.Sandbox.Tests/DocScan/Request/Check/SandboxDocumentTextDataCheckBuilderTests.cs
+++ b/Yoti.Auth.Sandbox.Tests/DocScan/Request/Check/SandboxDocumentTextDataCheckBuilderTests.cs
@@ -46,6 +46,19 @@ namespace Yoti.Auth.Sandbox.Tests.DocScan.Request.Check
         }
 
         [Fact]
+        public void ShouldBuildWithoutDocumentFields()
+        {
+            var check = new SandboxDocumentTextDataCheckBuilder()
+                .WithBreakdown(_someBreakDown)
+                .WithRecommendation(_someRecommendation)
+                .Build();
+
+            var sandboxTextDataCheckResult = (SandboxDocumentTextDataCheckResult)check.Result;
+
+            Assert.Null(sandboxTextDataCheckResult.DocumentFields);
+        }
+
+        [Fact]
         public void ShouldBuildWithDocumentFields()
         {
             var documentFields = new Dictionary<string, object>

--- a/Yoti.Auth.Sandbox.Tests/DocScan/Request/Task/SandboxDocumentTextDataExtractionTaskBuilderTest.cs
+++ b/Yoti.Auth.Sandbox.Tests/DocScan/Request/Task/SandboxDocumentTextDataExtractionTaskBuilderTest.cs
@@ -1,0 +1,61 @@
+using Xunit;
+using System.Collections.Generic;
+using Yoti.Auth.Sandbox.DocScan.Request.Task;
+
+namespace Yoti.Auth.Sandbox.Tests.DocScan.Request.Task
+{
+    public class SandboxDocumentTextDataExtractionTaskBuilderTest
+    {
+        private readonly string _someKey = "someKey";
+        private readonly string _someValue = "someValue";
+        private readonly string _someOtherKey = "someOtherKey";
+        private readonly string _someOtherValue = "someOtherValue";
+
+        [Fact]
+        public void ShouldBuildWithDocumentField()
+        {
+            var task = new SandboxDocumentTextDataExtractionTaskBuilder()
+                .WithDocumentField(_someKey, _someValue)
+                .Build();
+
+            Assert.Equal(_someValue, task.Result.DocumentFields[_someKey]);
+        }
+
+        [Fact]
+        public void ShouldBuildWithDocumentFieldMultiple()
+        {
+            var task = new SandboxDocumentTextDataExtractionTaskBuilder()
+                .WithDocumentField(_someKey, _someValue)
+                .WithDocumentField(_someOtherKey, _someOtherValue)
+                .Build();
+
+            Assert.Equal(_someValue, task.Result.DocumentFields[_someKey]);
+            Assert.Equal(_someOtherValue, task.Result.DocumentFields[_someOtherKey]);
+        }
+
+        [Fact]
+        public void ShouldBuildWithDocumentFields()
+        {
+            var documentFields = new Dictionary<string, object>
+            {
+                { _someKey, _someValue },
+                { _someOtherKey, _someOtherValue }
+            };
+
+            var task = new SandboxDocumentTextDataExtractionTaskBuilder()
+                .WithDocumentFields(documentFields)
+                .Build();
+
+            Assert.Equal(_someValue, task.Result.DocumentFields[_someKey]);
+            Assert.Equal(_someOtherValue, task.Result.DocumentFields[_someOtherKey]);
+        }
+
+        [Fact]
+        public void ShouldBuildWithoutDocumentFields()
+        {
+            var task = new SandboxDocumentTextDataExtractionTaskBuilder().Build();
+
+            Assert.Null(task.Result.DocumentFields);
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxDocumentTextDataCheckBuilder.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxDocumentTextDataCheckBuilder.cs
@@ -5,10 +5,13 @@ namespace Yoti.Auth.Sandbox.DocScan.Request.Check
     public class SandboxDocumentTextDataCheckBuilder
         : SandboxDocumentCheckBuilder<SandboxDocumentTextDataCheckBuilder, SandboxDocumentTextDataCheck>
     {
-        private Dictionary<string, object> _documentFields = new Dictionary<string, object>();
+        private Dictionary<string, object> _documentFields;
 
         public SandboxDocumentTextDataCheckBuilder WithDocumentField(string key, object value)
         {
+            if (_documentFields == null) {
+                _documentFields = new Dictionary<string, object>();
+            }
             _documentFields.Add(key, value);
             return this;
         }

--- a/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentTextDataExtractionTaskBuilder.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentTextDataExtractionTaskBuilder.cs
@@ -4,11 +4,14 @@ namespace Yoti.Auth.Sandbox.DocScan.Request.Task
 {
     public class SandboxDocumentTextDataExtractionTaskBuilder : SandboxTaskResult
     {
-        private Dictionary<string, object> _documentFields = new Dictionary<string, object>();
+        private Dictionary<string, object> _documentFields;
         private SandboxDocumentFilter _documentFilter;
 
         public SandboxDocumentTextDataExtractionTaskBuilder WithDocumentField(string key, object value)
         {
+            if (_documentFields == null) {
+                _documentFields = new Dictionary<string, object>();
+            }
             _documentFields.Add(key, value);
             return this;
         }


### PR DESCRIPTION
### Fixed
- Document fields are excluded from JSON when not set