### PR TITLE
SDK-1758: Add ability to set chip data - document ID photo

### DIFF
--- a/Yoti.Auth.Sandbox.Tests/DocScan/Request/Task/SandboxDocumentTextDataExtractionTaskBuilderTest.cs
+++ b/Yoti.Auth.Sandbox.Tests/DocScan/Request/Task/SandboxDocumentTextDataExtractionTaskBuilderTest.cs
@@ -1,6 +1,8 @@
 using Xunit;
 using System.Collections.Generic;
 using Yoti.Auth.Sandbox.DocScan.Request.Task;
+using System;
+using System.Text;
 
 namespace Yoti.Auth.Sandbox.Tests.DocScan.Request.Task
 {
@@ -51,11 +53,26 @@ namespace Yoti.Auth.Sandbox.Tests.DocScan.Request.Task
         }
 
         [Fact]
-        public void ShouldBuildWithoutDocumentFields()
+        public void ShouldBuildWithoutMethods()
         {
             var task = new SandboxDocumentTextDataExtractionTaskBuilder().Build();
 
             Assert.Null(task.Result.DocumentFields);
+            Assert.Null(task.Result.DocumentIdPhoto);
+        }
+
+        [Fact]
+        public void ShouldBuildWithDocumentIdPhoto()
+        {
+            byte[] imageBytes = Encoding.UTF8.GetBytes("someImage");
+            string contentType = "image/jpeg";
+
+            var task = new SandboxDocumentTextDataExtractionTaskBuilder()
+                .WithDocumentIdPhoto(contentType, imageBytes)
+                .Build();
+
+            Assert.Equal(contentType, task.Result.DocumentIdPhoto.ContentType);
+            Assert.Equal(Convert.ToBase64String(imageBytes), task.Result.DocumentIdPhoto.Base64Data);
         }
     }
 }

--- a/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentIdPhoto.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentIdPhoto.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request.Task
+{
+    public class SandboxDocumentIdPhoto
+    {
+        [JsonProperty(PropertyName = "content_type")]
+        public string ContentType { get; }
+
+        [JsonProperty(PropertyName = "data")]
+        public string Base64Data { get; }
+
+        public SandboxDocumentIdPhoto(string contentType, string base64Data)
+        {
+            ContentType = contentType;
+            Base64Data = base64Data;
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentTextDataExtractionTaskBuilder.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentTextDataExtractionTaskBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Yoti.Auth.Sandbox.DocScan.Request.Task
 {
@@ -6,6 +7,7 @@ namespace Yoti.Auth.Sandbox.DocScan.Request.Task
     {
         private Dictionary<string, object> _documentFields;
         private SandboxDocumentFilter _documentFilter;
+        private SandboxDocumentIdPhoto _documentIdPhoto;
 
         public SandboxDocumentTextDataExtractionTaskBuilder WithDocumentField(string key, object value)
         {
@@ -29,9 +31,16 @@ namespace Yoti.Auth.Sandbox.DocScan.Request.Task
             return this;
         }
 
+        public SandboxDocumentTextDataExtractionTaskBuilder WithDocumentIdPhoto(string contentType, byte[] documentIdPhoto)
+        {
+            string base64DocumentIdPhoto = Convert.ToBase64String(documentIdPhoto);
+            _documentIdPhoto = new SandboxDocumentIdPhoto(contentType, base64DocumentIdPhoto);
+            return this;
+        }
+
         public SandboxDocumentTextDataExtractionTask Build()
         {
-            SandboxDocumentTextDataExtractionTaskResult result = new SandboxDocumentTextDataExtractionTaskResult(_documentFields);
+            SandboxDocumentTextDataExtractionTaskResult result = new SandboxDocumentTextDataExtractionTaskResult(_documentFields, _documentIdPhoto);
             return new SandboxDocumentTextDataExtractionTask(result, _documentFilter);
         }
     }

--- a/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentTextDataExtractionTaskResult.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentTextDataExtractionTaskResult.cs
@@ -8,9 +8,15 @@ namespace Yoti.Auth.Sandbox.DocScan.Request.Task
         [JsonProperty(PropertyName = "document_fields")]
         public Dictionary<string, object> DocumentFields { get; }
 
-        public SandboxDocumentTextDataExtractionTaskResult(Dictionary<string, object> documentFields)
+        [JsonProperty(PropertyName = "document_id_photo")]
+        public SandboxDocumentIdPhoto DocumentIdPhoto { get; }
+
+        public SandboxDocumentTextDataExtractionTaskResult(
+            Dictionary<string, object> documentFields,
+            SandboxDocumentIdPhoto sandboxDocumentIdPhoto = null)
         {
             DocumentFields = documentFields;
+            DocumentIdPhoto = sandboxDocumentIdPhoto;
         }
     }
 }


### PR DESCRIPTION
### Added
- Document ID Photo, added with:
  - `SandboxDocumentTextDataExtractionTaskBuilder().WithDocumentIdPhoto(contentType, imageBytes)`