### PR TITLE
SDK-1790: Allow in-session feedback to be specified

### DIFF
--- a/Yoti.Auth.Sandbox.Tests/DocScan/DocScanSandboxClientTests.cs
+++ b/Yoti.Auth.Sandbox.Tests/DocScan/DocScanSandboxClientTests.cs
@@ -93,7 +93,7 @@ namespace Yoti.Auth.Sandbox.Tests.DocScan
                     _sandboxResponseConfig);
                 });
 
-                Assert.Contains("Error when setting up Doc Scan session response", exception.Message, StringComparison.Ordinal);
+                Assert.Contains("Failed validation - Status Code: '400' (BadRequest). Content: '{}'", exception.Message, StringComparison.Ordinal);
             };
         }
 
@@ -161,7 +161,7 @@ namespace Yoti.Auth.Sandbox.Tests.DocScan
                     _sandboxResponseConfig);
                 });
 
-                Assert.Contains("Error when setting up Doc Scan application response", exception.Message, StringComparison.Ordinal);
+                Assert.Contains("Failed validation - Status Code: '400' (BadRequest). Content: '{}'", exception.Message, StringComparison.Ordinal);
             };
         }
     }

--- a/Yoti.Auth.Sandbox.Tests/DocScan/Request/Task/SandboxDocumentTextDataExtractionReasonTests.cs
+++ b/Yoti.Auth.Sandbox.Tests/DocScan/Request/Task/SandboxDocumentTextDataExtractionReasonTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+using Yoti.Auth.Sandbox.DocScan.Request.Task;
+
+namespace Yoti.Auth.Sandbox.Tests.DocScan.Request.Task
+{
+    public class SandboxDocumentTextDataExtractionReasonTests
+    {
+        private readonly string _someReasonDetail = "someReasonDetail";
+
+        [Fact]
+        public void ShouldBuildForQuality()
+        {
+            var task = new SandboxDocumentTextDataExtractionReasonBuilder()
+                .ForQuality()
+                .Build();
+
+            Assert.Equal("QUALITY", task.Value);
+        }
+
+        [Fact]
+        public void ShouldBuildForUserError()
+        {
+            var task = new SandboxDocumentTextDataExtractionReasonBuilder()
+                .ForUserError()
+                .Build();
+
+            Assert.Equal("USER_ERROR", task.Value);
+        }
+
+        [Fact]
+        public void ShouldBuildForAReasonDetail()
+        {
+            var task = new SandboxDocumentTextDataExtractionReasonBuilder()
+                .WithDetail(_someReasonDetail)
+                .Build();
+
+            Assert.Equal(_someReasonDetail, task.Detail);
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox.Tests/DocScan/Request/Task/SandboxDocumentTextDataExtractionRecommendationTests.cs
+++ b/Yoti.Auth.Sandbox.Tests/DocScan/Request/Task/SandboxDocumentTextDataExtractionRecommendationTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+using Yoti.Auth.Sandbox.DocScan.Request.Task;
+
+namespace Yoti.Auth.Sandbox.Tests.DocScan.Request.Task
+{
+    public class SandboxDocumentTextDataExtractionRecommendationTests
+    {
+        private readonly string _someReasonDetail = "someReasonDetail";
+
+        [Fact]
+        public void ShouldBuildWithRecommendationForProgress()
+        {
+            var task = new SandboxDocumentTextDataExtractionRecommendationBuilder()
+                .ForProgress()
+                .Build();
+
+            Assert.Equal("PROGRESS", task.Value);
+        }
+
+        [Fact]
+        public void ShouldBuildWithRecommendationShouldTryAgain()
+        {
+            var task = new SandboxDocumentTextDataExtractionRecommendationBuilder()
+                .ForShouldTryAgain()
+                .Build();
+
+            Assert.Equal("SHOULD_TRY_AGAIN", task.Value);
+        }
+
+        [Fact]
+        public void ShouldBuildWithRecommendationMustTryAgain()
+        {
+            var task = new SandboxDocumentTextDataExtractionRecommendationBuilder()
+                .ForMustTryAgain()
+                .Build();
+
+            Assert.Equal("MUST_TRY_AGAIN", task.Value);
+        }
+
+        [Fact]
+        public void ShouldBuildWithReason()
+        {
+            SandboxDocumentTextDataExtractionReason _someReason = new SandboxDocumentTextDataExtractionReason("value", "details");
+
+            var task = new SandboxDocumentTextDataExtractionRecommendationBuilder()
+                .WithReason(_someReason)
+                .Build();
+
+            Assert.Equal(_someReason, task.Reason);
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox.Tests/DocScan/Request/Task/SandboxDocumentTextDataExtractionRecommendationTests.cs
+++ b/Yoti.Auth.Sandbox.Tests/DocScan/Request/Task/SandboxDocumentTextDataExtractionRecommendationTests.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Xunit;
 using Yoti.Auth.Sandbox.DocScan.Request.Task;
 
@@ -8,8 +5,6 @@ namespace Yoti.Auth.Sandbox.Tests.DocScan.Request.Task
 {
     public class SandboxDocumentTextDataExtractionRecommendationTests
     {
-        private readonly string _someReasonDetail = "someReasonDetail";
-
         [Fact]
         public void ShouldBuildWithRecommendationForProgress()
         {

--- a/Yoti.Auth.Sandbox.Tests/DocScan/Request/Task/SandboxDocumentTextDataExtractionTaskBuilderTests.cs
+++ b/Yoti.Auth.Sandbox.Tests/DocScan/Request/Task/SandboxDocumentTextDataExtractionTaskBuilderTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+using Yoti.Auth.Sandbox.DocScan.Request.Task;
+
+namespace Yoti.Auth.Sandbox.Tests.DocScan.Request.Task
+{
+    public class SandboxDocumentTextDataExtractionTaskBuilderTests
+    {
+        private readonly string _someKey = "someKey";
+        private readonly string _someValue = "someValue";
+        private readonly string _someOtherKey = "someOtherKey";
+        private readonly string _someOtherValue = "someOtherValue";
+
+        [Fact]
+        public void ShouldBuildWithDocumentField()
+        {
+            var task = new SandboxDocumentTextDataExtractionTaskBuilder()
+                .WithDocumentField(_someKey, _someValue)
+                .Build();
+
+            Assert.Equal(_someValue, task.Result.DocumentFields[_someKey]);
+        }
+
+        [Fact]
+        public void ShouldBuildWithDocumentFieldMultiple()
+        {
+            var task = new SandboxDocumentTextDataExtractionTaskBuilder()
+                .WithDocumentField(_someKey, _someValue)
+                .WithDocumentField(_someOtherKey, _someOtherValue)
+                .Build();
+
+            Assert.Equal(_someValue, task.Result.DocumentFields[_someKey]);
+            Assert.Equal(_someOtherValue, task.Result.DocumentFields[_someOtherKey]);
+        }
+
+        [Fact]
+        public void ShouldBuildWithDocumentFields()
+        {
+            var documentFields = new Dictionary<string, object>
+            {
+                { _someKey, _someValue },
+                { _someOtherKey, _someOtherValue }
+            };
+
+            var task = new SandboxDocumentTextDataExtractionTaskBuilder()
+                .WithDocumentFields(documentFields)
+                .Build();
+
+            Assert.Equal(_someValue, task.Result.DocumentFields[_someKey]);
+            Assert.Equal(_someOtherValue, task.Result.DocumentFields[_someOtherKey]);
+        }
+
+        [Fact]
+        public void ShouldBuildWithoutMethods()
+        {
+            var task = new SandboxDocumentTextDataExtractionTaskBuilder().Build();
+
+            Assert.Null(task.Result.DocumentFields);
+            Assert.Null(task.Result.DocumentIdPhoto);
+        }
+
+        [Fact]
+        public void ShouldBuildWithDocumentIdPhoto()
+        {
+            byte[] imageBytes = Encoding.UTF8.GetBytes("someImage");
+            string contentType = "image/jpeg";
+
+            var task = new SandboxDocumentTextDataExtractionTaskBuilder()
+                .WithDocumentIdPhoto(contentType, imageBytes)
+                .Build();
+
+            Assert.Equal(contentType, task.Result.DocumentIdPhoto.ContentType);
+            Assert.Equal(Convert.ToBase64String(imageBytes), task.Result.DocumentIdPhoto.Base64Data);
+        }
+
+        [Fact]
+        public void ShouldBuildWithDetectedCountry()
+        {
+            var task = new SandboxDocumentTextDataExtractionTaskBuilder()
+                .WithDetectedCountry("GBR")
+                .Build();
+
+            Assert.Equal("GBR", task.Result.DetectedCountry);
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox.Tests/DocScan/Request/Task/SandboxDocumentTextDataExtractionTaskBuilderTests.cs
+++ b/Yoti.Auth.Sandbox.Tests/DocScan/Request/Task/SandboxDocumentTextDataExtractionTaskBuilderTests.cs
@@ -53,6 +53,30 @@ namespace Yoti.Auth.Sandbox.Tests.DocScan.Request.Task
         }
 
         [Fact]
+        public void ShouldBuildWithDocumentFilter()
+        {
+            var documentFilter = new SandboxDocumentFilterBuilder().Build();
+
+            var task = new SandboxDocumentTextDataExtractionTaskBuilder()
+                .WithDocumentFilter(documentFilter)
+                .Build();
+
+            Assert.Equal(documentFilter, task.DocumentFilter);
+        }
+
+        [Fact]
+        public void ShouldBuildWithRecommendation()
+        {
+            var recommendation = new SandboxDocumentTextDataExtractionRecommendationBuilder().Build();
+
+            var task = new SandboxDocumentTextDataExtractionTaskBuilder()
+                .WithRecommendation(recommendation)
+                .Build();
+
+            Assert.Equal(recommendation, task.Result.Recommendation);
+        }
+
+        [Fact]
         public void ShouldBuildWithoutMethods()
         {
             var task = new SandboxDocumentTextDataExtractionTaskBuilder().Build();

--- a/Yoti.Auth.Sandbox.Tests/Profile/Request/Attribute/Derivation/SandboxAgeVerificationTests.cs
+++ b/Yoti.Auth.Sandbox.Tests/Profile/Request/Attribute/Derivation/SandboxAgeVerificationTests.cs
@@ -84,9 +84,9 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request.Attribute.Derivation
                 .Build()
                 .ToAttribute();
 
-            Assert.Equal(Constants.UserProfile.DateOfBirthAttribute, result.Name);
+            Assert.Equal(Yoti.Auth.Constants.UserProfile.DateOfBirthAttribute, result.Name);
             Assert.Equal(_validDateString, result.Value);
-            Assert.Equal($"{Constants.UserProfile.AgeOverAttribute}:{21}", result.Derivation);
+            Assert.Equal($"{Yoti.Auth.Constants.UserProfile.AgeOverAttribute}:{21}", result.Derivation);
 #pragma warning disable 0618
             Assert.Equal("False", result.Optional); //NOSONAR
 #pragma warning restore 0618
@@ -102,9 +102,9 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request.Attribute.Derivation
                 .Build()
                 .ToAttribute();
 
-            Assert.Equal(Constants.UserProfile.DateOfBirthAttribute, result.Name);
+            Assert.Equal(Yoti.Auth.Constants.UserProfile.DateOfBirthAttribute, result.Name);
             Assert.Equal(_validDateString, result.Value);
-            Assert.Equal($"{Constants.UserProfile.AgeUnderAttribute}:{16}", result.Derivation);
+            Assert.Equal($"{Yoti.Auth.Constants.UserProfile.AgeUnderAttribute}:{16}", result.Derivation);
 #pragma warning disable 0618
             Assert.Equal("False", result.Optional); //NOSONAR
 #pragma warning restore 0618
@@ -122,9 +122,9 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request.Attribute.Derivation
                 .Build()
                 .ToAttribute();
 
-            Assert.Equal(Constants.UserProfile.DateOfBirthAttribute, result.Name);
+            Assert.Equal(Yoti.Auth.Constants.UserProfile.DateOfBirthAttribute, result.Name);
             Assert.Equal(_validDateString, result.Value);
-            Assert.Equal($"{Constants.UserProfile.AgeUnderAttribute}:{16}", result.Derivation);
+            Assert.Equal($"{Yoti.Auth.Constants.UserProfile.AgeUnderAttribute}:{16}", result.Derivation);
 #pragma warning disable 0618
             Assert.Equal("False", result.Optional); //NOSONAR
 #pragma warning restore 0618

--- a/Yoti.Auth.Sandbox.Tests/Profile/Request/YotiTokenRequestTests.cs
+++ b/Yoti.Auth.Sandbox.Tests/Profile/Request/YotiTokenRequestTests.cs
@@ -115,7 +115,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             Assert.True(result.Count == 1);
             AttributeMatcher.AssertContainsAttribute(
                 result,
-                name: Constants.UserProfile.FamilyNameAttribute,
+                name: Yoti.Auth.Constants.UserProfile.FamilyNameAttribute,
                 value: _someFamilyName);
         }
 
@@ -132,7 +132,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             Assert.True(result.Count == 1);
             AttributeMatcher.AssertContainsAttribute(
                 result,
-                Constants.UserProfile.FamilyNameAttribute,
+                Yoti.Auth.Constants.UserProfile.FamilyNameAttribute,
                 _someFamilyName,
                 anchors);
         }
@@ -147,7 +147,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             ReadOnlyCollection<SandboxAttribute> result = yotiTokenRequest.SandboxAttributes;
 
             Assert.True(result.Count == 1);
-            AttributeMatcher.AssertContainsAttribute(result, Constants.UserProfile.GivenNamesAttribute, _someGivenNames);
+            AttributeMatcher.AssertContainsAttribute(result, Yoti.Auth.Constants.UserProfile.GivenNamesAttribute, _someGivenNames);
         }
 
         [Fact]
@@ -160,7 +160,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             ReadOnlyCollection<SandboxAttribute> result = yotiTokenRequest.SandboxAttributes;
 
             Assert.True(result.Count == 1);
-            AttributeMatcher.AssertContainsAttribute(result, Constants.UserProfile.GivenNamesAttribute, _someGivenNames, anchors);
+            AttributeMatcher.AssertContainsAttribute(result, Yoti.Auth.Constants.UserProfile.GivenNamesAttribute, _someGivenNames, anchors);
         }
 
         [Fact]
@@ -173,7 +173,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             ReadOnlyCollection<SandboxAttribute> result = yotiTokenRequest.SandboxAttributes;
 
             Assert.True(result.Count == 1);
-            AttributeMatcher.AssertContainsAttribute(result, Constants.UserProfile.FullNameAttribute, _someFullName);
+            AttributeMatcher.AssertContainsAttribute(result, Yoti.Auth.Constants.UserProfile.FullNameAttribute, _someFullName);
         }
 
         [Fact]
@@ -186,7 +186,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             ReadOnlyCollection<SandboxAttribute> result = yotiTokenRequest.SandboxAttributes;
 
             Assert.True(result.Count == 1);
-            AttributeMatcher.AssertContainsAttribute(result, Constants.UserProfile.FullNameAttribute, _someFullName, anchors);
+            AttributeMatcher.AssertContainsAttribute(result, Yoti.Auth.Constants.UserProfile.FullNameAttribute, _someFullName, anchors);
         }
 
         [Fact]
@@ -199,7 +199,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             ReadOnlyCollection<SandboxAttribute> result = yotiTokenRequest.SandboxAttributes;
 
             Assert.True(result.Count == 1);
-            AttributeMatcher.AssertContainsAttribute(result, Constants.UserProfile.GenderAttribute, _someGender);
+            AttributeMatcher.AssertContainsAttribute(result, Yoti.Auth.Constants.UserProfile.GenderAttribute, _someGender);
         }
 
         [Fact]
@@ -212,7 +212,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             ReadOnlyCollection<SandboxAttribute> result = yotiTokenRequest.SandboxAttributes;
 
             Assert.True(result.Count == 1);
-            AttributeMatcher.AssertContainsAttribute(result, Constants.UserProfile.GenderAttribute, _someGender, anchors);
+            AttributeMatcher.AssertContainsAttribute(result, Yoti.Auth.Constants.UserProfile.GenderAttribute, _someGender, anchors);
         }
 
         [Fact]
@@ -225,7 +225,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             ReadOnlyCollection<SandboxAttribute> result = yotiTokenRequest.SandboxAttributes;
 
             Assert.True(result.Count == 1);
-            AttributeMatcher.AssertContainsAttribute(result, Constants.UserProfile.DateOfBirthAttribute, _someDoB);
+            AttributeMatcher.AssertContainsAttribute(result, Yoti.Auth.Constants.UserProfile.DateOfBirthAttribute, _someDoB);
         }
 
         [Fact]
@@ -238,7 +238,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             ReadOnlyCollection<SandboxAttribute> result = yotiTokenRequest.SandboxAttributes;
 
             Assert.True(result.Count == 1);
-            AttributeMatcher.AssertContainsAttribute(result, Constants.UserProfile.DateOfBirthAttribute, _someDoB, anchors);
+            AttributeMatcher.AssertContainsAttribute(result, Yoti.Auth.Constants.UserProfile.DateOfBirthAttribute, _someDoB, anchors);
         }
 
         [Fact]
@@ -259,7 +259,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             ReadOnlyCollection<SandboxAttribute> result = yotiTokenRequest.SandboxAttributes;
 
             Assert.True(result.Count == 1);
-            AttributeMatcher.AssertContainsAttribute(result, Constants.UserProfile.DateOfBirthAttribute, _someDoB);
+            AttributeMatcher.AssertContainsAttribute(result, Yoti.Auth.Constants.UserProfile.DateOfBirthAttribute, _someDoB);
         }
 
         [Fact]
@@ -280,7 +280,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             ReadOnlyCollection<SandboxAttribute> result = yotiTokenRequest.SandboxAttributes;
 
             Assert.True(result.Count == 1);
-            AttributeMatcher.AssertContainsAttribute(result, Constants.UserProfile.DateOfBirthAttribute, _someDoB, anchors);
+            AttributeMatcher.AssertContainsAttribute(result, Yoti.Auth.Constants.UserProfile.DateOfBirthAttribute, _someDoB, anchors);
         }
 
         [Fact]
@@ -299,7 +299,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             Assert.True(result.Count == 1);
             AttributeMatcher.AssertContainsDerivedAttribute(
                 result,
-                Constants.UserProfile.DateOfBirthAttribute,
+                Yoti.Auth.Constants.UserProfile.DateOfBirthAttribute,
                 _dobUnder18,
                 "age_under:18");
         }
@@ -320,7 +320,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             Assert.True(result.Count == 1);
             AttributeMatcher.AssertContainsDerivedAttribute(
                 result,
-                Constants.UserProfile.DateOfBirthAttribute,
+                Yoti.Auth.Constants.UserProfile.DateOfBirthAttribute,
                 _dobOver18,
                 "age_over:18");
         }
@@ -346,12 +346,12 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             Assert.True(result.Count == 2);
             AttributeMatcher.AssertContainsDerivedAttribute(
                 result,
-                Constants.UserProfile.DateOfBirthAttribute,
+                Yoti.Auth.Constants.UserProfile.DateOfBirthAttribute,
                 _dobOver18,
                 "age_over:18");
             AttributeMatcher.AssertContainsDerivedAttribute(
                 result,
-                Constants.UserProfile.DateOfBirthAttribute,
+                Yoti.Auth.Constants.UserProfile.DateOfBirthAttribute,
                 _dobOver18,
                 "age_under:18");
         }
@@ -366,7 +366,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             ReadOnlyCollection<SandboxAttribute> result = yotiTokenRequest.SandboxAttributes;
 
             Assert.True(result.Count == 1);
-            AttributeMatcher.AssertContainsAttribute(result, Constants.UserProfile.PostalAddressAttribute, _somePostalAddress);
+            AttributeMatcher.AssertContainsAttribute(result, Yoti.Auth.Constants.UserProfile.PostalAddressAttribute, _somePostalAddress);
         }
 
         [Fact]
@@ -379,7 +379,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             ReadOnlyCollection<SandboxAttribute> result = yotiTokenRequest.SandboxAttributes;
 
             Assert.True(result.Count == 1);
-            AttributeMatcher.AssertContainsAttribute(result, Constants.UserProfile.PostalAddressAttribute, _somePostalAddress, anchors);
+            AttributeMatcher.AssertContainsAttribute(result, Yoti.Auth.Constants.UserProfile.PostalAddressAttribute, _somePostalAddress, anchors);
         }
 
         [Fact]
@@ -392,7 +392,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             ReadOnlyCollection<SandboxAttribute> result = yotiTokenRequest.SandboxAttributes;
 
             Assert.True(result.Count == 1);
-            AttributeMatcher.AssertContainsAttribute(result, Constants.UserProfile.StructuredPostalAddressAttribute, _somePostalAddress);
+            AttributeMatcher.AssertContainsAttribute(result, Yoti.Auth.Constants.UserProfile.StructuredPostalAddressAttribute, _somePostalAddress);
         }
 
         [Fact]
@@ -405,7 +405,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             ReadOnlyCollection<SandboxAttribute> result = yotiTokenRequest.SandboxAttributes;
 
             Assert.True(result.Count == 1);
-            AttributeMatcher.AssertContainsAttribute(result, Constants.UserProfile.StructuredPostalAddressAttribute, _somePostalAddress, anchors);
+            AttributeMatcher.AssertContainsAttribute(result, Yoti.Auth.Constants.UserProfile.StructuredPostalAddressAttribute, _somePostalAddress, anchors);
         }
 
         [Fact]
@@ -418,7 +418,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             ReadOnlyCollection<SandboxAttribute> result = yotiTokenRequest.SandboxAttributes;
 
             Assert.True(result.Count == 1);
-            AttributeMatcher.AssertContainsAttribute(result, Constants.UserProfile.NationalityAttribute, _someNationality);
+            AttributeMatcher.AssertContainsAttribute(result, Yoti.Auth.Constants.UserProfile.NationalityAttribute, _someNationality);
         }
 
         [Fact]
@@ -431,7 +431,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             ReadOnlyCollection<SandboxAttribute> result = yotiTokenRequest.SandboxAttributes;
 
             Assert.True(result.Count == 1);
-            AttributeMatcher.AssertContainsAttribute(result, Constants.UserProfile.NationalityAttribute, _someNationality, anchors);
+            AttributeMatcher.AssertContainsAttribute(result, Yoti.Auth.Constants.UserProfile.NationalityAttribute, _someNationality, anchors);
         }
 
         [Fact]
@@ -444,7 +444,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             ReadOnlyCollection<SandboxAttribute> result = yotiTokenRequest.SandboxAttributes;
 
             Assert.True(result.Count == 1);
-            AttributeMatcher.AssertContainsAttribute(result, Constants.UserProfile.PhoneNumberAttribute, _somePhoneNumber);
+            AttributeMatcher.AssertContainsAttribute(result, Yoti.Auth.Constants.UserProfile.PhoneNumberAttribute, _somePhoneNumber);
         }
 
         [Fact]
@@ -457,7 +457,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             ReadOnlyCollection<SandboxAttribute> result = yotiTokenRequest.SandboxAttributes;
 
             Assert.True(result.Count == 1);
-            AttributeMatcher.AssertContainsAttribute(result, Constants.UserProfile.PhoneNumberAttribute, _somePhoneNumber, anchors);
+            AttributeMatcher.AssertContainsAttribute(result, Yoti.Auth.Constants.UserProfile.PhoneNumberAttribute, _somePhoneNumber, anchors);
         }
 
         [Fact]
@@ -470,7 +470,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             ReadOnlyCollection<SandboxAttribute> result = yotiTokenRequest.SandboxAttributes;
 
             Assert.True(result.Count == 1);
-            AttributeMatcher.AssertContainsAttribute(result, Constants.UserProfile.EmailAddressAttribute, _someEmailAddress);
+            AttributeMatcher.AssertContainsAttribute(result, Yoti.Auth.Constants.UserProfile.EmailAddressAttribute, _someEmailAddress);
         }
 
         [Fact]
@@ -483,7 +483,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             ReadOnlyCollection<SandboxAttribute> result = yotiTokenRequest.SandboxAttributes;
 
             Assert.True(result.Count == 1);
-            AttributeMatcher.AssertContainsAttribute(result, Constants.UserProfile.EmailAddressAttribute, _someEmailAddress, anchors);
+            AttributeMatcher.AssertContainsAttribute(result, Yoti.Auth.Constants.UserProfile.EmailAddressAttribute, _someEmailAddress, anchors);
         }
 
         [Fact]
@@ -501,7 +501,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             ReadOnlyCollection<SandboxAttribute> result = yotiTokenRequest.SandboxAttributes;
 
             Assert.True(result.Count == 1);
-            AttributeMatcher.AssertContainsAttribute(result, Constants.UserProfile.DocumentDetailsAttribute, "type country number");
+            AttributeMatcher.AssertContainsAttribute(result, Yoti.Auth.Constants.UserProfile.DocumentDetailsAttribute, "type country number");
         }
 
         [Fact]
@@ -521,7 +521,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             Assert.True(result.Count == 1);
             AttributeMatcher.AssertContainsAttribute(
                 result,
-                Constants.UserProfile.DocumentDetailsAttribute,
+                Yoti.Auth.Constants.UserProfile.DocumentDetailsAttribute,
                 "type country number",
                 anchors);
         }
@@ -536,7 +536,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             ReadOnlyCollection<SandboxAttribute> result = yotiTokenRequest.SandboxAttributes;
 
             Assert.True(result.Count == 1);
-            AttributeMatcher.AssertContainsAttribute(result, Constants.UserProfile.DocumentDetailsAttribute, _someDocumentDetails);
+            AttributeMatcher.AssertContainsAttribute(result, Yoti.Auth.Constants.UserProfile.DocumentDetailsAttribute, _someDocumentDetails);
         }
 
         [Fact]
@@ -549,7 +549,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             ReadOnlyCollection<SandboxAttribute> result = yotiTokenRequest.SandboxAttributes;
 
             Assert.True(result.Count == 1);
-            AttributeMatcher.AssertContainsAttribute(result, Constants.UserProfile.DocumentDetailsAttribute, _someDocumentDetails, anchors);
+            AttributeMatcher.AssertContainsAttribute(result, Yoti.Auth.Constants.UserProfile.DocumentDetailsAttribute, _someDocumentDetails, anchors);
         }
 
         [Fact]
@@ -569,7 +569,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             Assert.True(result.Count == 1);
             AttributeMatcher.AssertContainsAttribute(
                 result,
-                Constants.UserProfile.DocumentImagesAttribute,
+                Yoti.Auth.Constants.UserProfile.DocumentImagesAttribute,
                 _expectedDocumentImagesAttributeValue);
         }
 
@@ -590,7 +590,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             Assert.True(result.Count == 1);
             AttributeMatcher.AssertContainsAttribute(
                 result,
-                Constants.UserProfile.DocumentImagesAttribute,
+                Yoti.Auth.Constants.UserProfile.DocumentImagesAttribute,
                 _expectedDocumentImagesAttributeValue,
                 anchors);
         }
@@ -607,7 +607,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             Assert.True(result.Count == 1);
             AttributeMatcher.AssertContainsAttribute(
                 result,
-                Constants.UserProfile.SelfieAttribute,
+                Yoti.Auth.Constants.UserProfile.SelfieAttribute,
                 Conversion.BytesToBase64(
                     Encoding.UTF8.GetBytes(_someBase64Selfie)));
         }
@@ -624,7 +624,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             Assert.True(result.Count == 1);
             AttributeMatcher.AssertContainsAttribute(
                 result,
-                Constants.UserProfile.SelfieAttribute,
+                Yoti.Auth.Constants.UserProfile.SelfieAttribute,
                 Conversion.BytesToBase64(
                     Encoding.UTF8.GetBytes(_someBase64Selfie)),
                 anchors);
@@ -640,7 +640,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             ReadOnlyCollection<SandboxAttribute> result = yotiTokenRequest.SandboxAttributes;
 
             Assert.True(result.Count == 1);
-            AttributeMatcher.AssertContainsAttribute(result, Constants.UserProfile.SelfieAttribute, _someBase64Selfie);
+            AttributeMatcher.AssertContainsAttribute(result, Yoti.Auth.Constants.UserProfile.SelfieAttribute, _someBase64Selfie);
         }
 
         [Fact]
@@ -653,7 +653,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request
             ReadOnlyCollection<SandboxAttribute> result = yotiTokenRequest.SandboxAttributes;
 
             Assert.True(result.Count == 1);
-            AttributeMatcher.AssertContainsAttribute(result, Constants.UserProfile.SelfieAttribute, _someBase64Selfie, anchors);
+            AttributeMatcher.AssertContainsAttribute(result, Yoti.Auth.Constants.UserProfile.SelfieAttribute, _someBase64Selfie, anchors);
         }
 
         [Fact]

--- a/Yoti.Auth.Sandbox/Constants/DocScan.cs
+++ b/Yoti.Auth.Sandbox/Constants/DocScan.cs
@@ -1,0 +1,13 @@
+﻿namespace Yoti.Auth.Sandbox.Constants
+{
+    public static class DocScan
+
+    {
+        public const string Progress = "PROGRESS";
+        public const string ShouldTryAgain = "SHOULD_TRY_AGAIN";
+        public const string MustTryAgain = "MUST_TRY_AGAIN";
+
+        public const string Quality = "QUALITY";
+        public const string UserError = "USER_ERROR";
+    }
+}

--- a/Yoti.Auth.Sandbox/Constants/DocScanSandbox.cs
+++ b/Yoti.Auth.Sandbox/Constants/DocScanSandbox.cs
@@ -1,6 +1,6 @@
 ﻿namespace Yoti.Auth.Sandbox.Constants
 {
-    public static class DocScan
+    public static class DocScanSandbox
 
     {
         public const string Progress = "PROGRESS";

--- a/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxZoomLivenessCheckBuilder.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Check/SandboxZoomLivenessCheckBuilder.cs
@@ -10,7 +10,7 @@
             SandboxCheckReport report = new SandboxCheckReport(Recommendation, Breakdown);
             SandboxCheckResult result = new SandboxCheckResult(report);
 
-            return new SandboxLivenessCheck(result, Constants.DocScanConstants.Zoom);
+            return new SandboxLivenessCheck(result, Yoti.Auth.Constants.DocScanConstants.Zoom);
         }
     }
 }

--- a/Yoti.Auth.Sandbox/DocScan/Request/SandboxClient.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/SandboxClient.cs
@@ -10,7 +10,7 @@ namespace Yoti.Auth.Sandbox.DocScan.Request
     public class SandboxClient
     {
         private const string _yotiDocScanSandboxPathPrefix = "/sandbox/idverify/v1";
-        private readonly Uri _defaultDocScanSandboxApiUrl = new Uri(Constants.Api.DefaultYotiHost + _yotiDocScanSandboxPathPrefix);
+        private readonly Uri _defaultDocScanSandboxApiUrl = new Uri(Yoti.Auth.Constants.Api.DefaultYotiHost + _yotiDocScanSandboxPathPrefix);
 
         private readonly HttpClient _httpClient;
         internal Uri DocScanSandboxApiUrl { get; private set; }
@@ -32,68 +32,54 @@ namespace Yoti.Auth.Sandbox.DocScan.Request
 
         public void ConfigureSessionResponse(string sessionId, ResponseConfig sandboxExpection)
         {
-            try
-            {
-                string serializedSandboxResponseConfig = JsonConvert.SerializeObject(
-                    sandboxExpection,
-                    new JsonSerializerSettings
-                    {
-                        NullValueHandling = NullValueHandling.Ignore
-                    });
-                byte[] body = Encoding.UTF8.GetBytes(serializedSandboxResponseConfig);
-
-                Yoti.Auth.Web.Request request = new RequestBuilder()
-                    .WithKeyPair(_keyPair)
-                    .WithBaseUri(DocScanSandboxApiUrl)
-                    .WithEndpoint($"/sessions/{sessionId}/response-config")
-                    .WithHttpMethod(HttpMethod.Put)
-                    .WithContent(body)
-                    .WithQueryParam("sdkId", _sdkId)
-                    .Build();
-
-                HttpResponseMessage response = request.Execute(_httpClient).Result;
-
-                if (!response.IsSuccessStatusCode)
+            string serializedSandboxResponseConfig = JsonConvert.SerializeObject(
+                sandboxExpection,
+                new JsonSerializerSettings
                 {
-                    Response.CreateYotiExceptionFromStatusCode<SandboxException>(response);
-                }
-            }
-            catch (Exception ex)
+                    NullValueHandling = NullValueHandling.Ignore
+                });
+            byte[] body = Encoding.UTF8.GetBytes(serializedSandboxResponseConfig);
+
+            Yoti.Auth.Web.Request request = new RequestBuilder()
+                .WithKeyPair(_keyPair)
+                .WithBaseUri(DocScanSandboxApiUrl)
+                .WithEndpoint($"/sessions/{sessionId}/response-config")
+                .WithHttpMethod(HttpMethod.Put)
+                .WithContent(body)
+                .WithQueryParam("sdkId", _sdkId)
+                .Build();
+
+            HttpResponseMessage response = request.Execute(_httpClient).Result;
+
+            if (!response.IsSuccessStatusCode)
             {
-                throw new SandboxException(Properties.Resources.DocScanSessionResponseError, ex);
+                Response.CreateYotiExceptionFromStatusCode<SandboxException>(response);
             }
         }
 
         public void ConfigureApplicationResponse(ResponseConfig sandboxExpection)
         {
-            try
+            string serializedSandboxResponseConfig = JsonConvert.SerializeObject(
+               sandboxExpection,
+               new JsonSerializerSettings
+               {
+                   NullValueHandling = NullValueHandling.Ignore
+               });
+            byte[] body = Encoding.UTF8.GetBytes(serializedSandboxResponseConfig);
+
+            Yoti.Auth.Web.Request request = new RequestBuilder()
+                .WithKeyPair(_keyPair)
+                .WithBaseUri(DocScanSandboxApiUrl)
+                .WithEndpoint($"/apps/{_sdkId}/response-config")
+                .WithHttpMethod(HttpMethod.Put)
+                .WithContent(body)
+                .Build();
+
+            HttpResponseMessage response = request.Execute(_httpClient).Result;
+
+            if (!response.IsSuccessStatusCode)
             {
-                string serializedSandboxResponseConfig = JsonConvert.SerializeObject(
-                   sandboxExpection,
-                   new JsonSerializerSettings
-                   {
-                       NullValueHandling = NullValueHandling.Ignore
-                   });
-                byte[] body = Encoding.UTF8.GetBytes(serializedSandboxResponseConfig);
-
-                Yoti.Auth.Web.Request request = new RequestBuilder()
-                    .WithKeyPair(_keyPair)
-                    .WithBaseUri(DocScanSandboxApiUrl)
-                    .WithEndpoint($"/apps/{_sdkId}/response-config")
-                    .WithHttpMethod(HttpMethod.Put)
-                    .WithContent(body)
-                    .Build();
-
-                HttpResponseMessage response = request.Execute(_httpClient).Result;
-
-                if (!response.IsSuccessStatusCode)
-                {
-                    Response.CreateYotiExceptionFromStatusCode<SandboxException>(response);
-                }
-            }
-            catch (Exception ex)
-            {
-                throw new SandboxException(Properties.Resources.DocScanApplicationResponseError, ex);
+                Response.CreateYotiExceptionFromStatusCode<SandboxException>(response);
             }
         }
     }

--- a/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentTextDataExtractionReason.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentTextDataExtractionReason.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request.Task
+{
+    public class SandboxDocumentTextDataExtractionReason
+    {
+        public SandboxDocumentTextDataExtractionReason(string value, string detail)
+        {
+            Value = value;
+            Detail = detail;
+        }
+
+        [JsonProperty(PropertyName = "value")]
+        public string Value { get; }
+
+        [JsonProperty(PropertyName = "detail")]
+        public string Detail { get; }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentTextDataExtractionReasonBuilder.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentTextDataExtractionReasonBuilder.cs
@@ -7,13 +7,13 @@
 
         public SandboxDocumentTextDataExtractionReasonBuilder ForQuality()
         {
-            _value = Constants.DocScan.Quality;
+            _value = Constants.DocScanSandbox.Quality;
             return this;
         }
 
         public SandboxDocumentTextDataExtractionReasonBuilder ForUserError()
         {
-            _value = Constants.DocScan.UserError;
+            _value = Constants.DocScanSandbox.UserError;
             return this;
         }
 

--- a/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentTextDataExtractionReasonBuilder.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentTextDataExtractionReasonBuilder.cs
@@ -1,0 +1,31 @@
+﻿namespace Yoti.Auth.Sandbox.DocScan.Request.Task
+{
+    public class SandboxDocumentTextDataExtractionReasonBuilder : SandboxTaskResult
+    {
+        private string _value;
+        private string _detail;
+
+        public SandboxDocumentTextDataExtractionReasonBuilder ForQuality()
+        {
+            _value = Constants.DocScan.Quality;
+            return this;
+        }
+
+        public SandboxDocumentTextDataExtractionReasonBuilder ForUserError()
+        {
+            _value = Constants.DocScan.UserError;
+            return this;
+        }
+
+        public SandboxDocumentTextDataExtractionReasonBuilder WithDetail(string detail)
+        {
+            _detail = detail;
+            return this;
+        }
+
+        public SandboxDocumentTextDataExtractionReason Build()
+        {
+            return new SandboxDocumentTextDataExtractionReason(_value, _detail);
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentTextDataExtractionRecommendation.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentTextDataExtractionRecommendation.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+
+namespace Yoti.Auth.Sandbox.DocScan.Request.Task
+{
+    public class SandboxDocumentTextDataExtractionRecommendation : SandboxTaskResult
+    {
+        public SandboxDocumentTextDataExtractionRecommendation(string value, SandboxDocumentTextDataExtractionReason reason)
+        {
+            Value = value;
+            Reason = reason;
+        }
+
+        [JsonProperty(PropertyName = "value")]
+        public string Value { get; }
+
+        [JsonProperty(PropertyName = "reason")]
+        public SandboxDocumentTextDataExtractionReason Reason { get; }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentTextDataExtractionRecommendationBuilder.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentTextDataExtractionRecommendationBuilder.cs
@@ -1,0 +1,37 @@
+﻿namespace Yoti.Auth.Sandbox.DocScan.Request.Task
+{
+    public class SandboxDocumentTextDataExtractionRecommendationBuilder : SandboxTaskResult
+    {
+        private string _recommendationvalue;
+        private SandboxDocumentTextDataExtractionReason _reason;
+
+        public SandboxDocumentTextDataExtractionRecommendationBuilder ForProgress()
+        {
+            _recommendationvalue = Constants.DocScan.Progress;
+            return this;
+        }
+
+        public SandboxDocumentTextDataExtractionRecommendationBuilder ForShouldTryAgain()
+        {
+            _recommendationvalue = Constants.DocScan.ShouldTryAgain;
+            return this;
+        }
+
+        public SandboxDocumentTextDataExtractionRecommendationBuilder ForMustTryAgain()
+        {
+            _recommendationvalue = Constants.DocScan.MustTryAgain;
+            return this;
+        }
+
+        public SandboxDocumentTextDataExtractionRecommendationBuilder WithReason(SandboxDocumentTextDataExtractionReason reason)
+        {
+            _reason = reason;
+            return this;
+        }
+
+        public SandboxDocumentTextDataExtractionRecommendation Build()
+        {
+            return new SandboxDocumentTextDataExtractionRecommendation(_recommendationvalue, _reason);
+        }
+    }
+}

--- a/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentTextDataExtractionRecommendationBuilder.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentTextDataExtractionRecommendationBuilder.cs
@@ -7,19 +7,19 @@
 
         public SandboxDocumentTextDataExtractionRecommendationBuilder ForProgress()
         {
-            _recommendationvalue = Constants.DocScan.Progress;
+            _recommendationvalue = Constants.DocScanSandbox.Progress;
             return this;
         }
 
         public SandboxDocumentTextDataExtractionRecommendationBuilder ForShouldTryAgain()
         {
-            _recommendationvalue = Constants.DocScan.ShouldTryAgain;
+            _recommendationvalue = Constants.DocScanSandbox.ShouldTryAgain;
             return this;
         }
 
         public SandboxDocumentTextDataExtractionRecommendationBuilder ForMustTryAgain()
         {
-            _recommendationvalue = Constants.DocScan.MustTryAgain;
+            _recommendationvalue = Constants.DocScanSandbox.MustTryAgain;
             return this;
         }
 

--- a/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentTextDataExtractionTaskBuilder.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentTextDataExtractionTaskBuilder.cs
@@ -8,6 +8,8 @@ namespace Yoti.Auth.Sandbox.DocScan.Request.Task
         private Dictionary<string, object> _documentFields;
         private SandboxDocumentFilter _documentFilter;
         private SandboxDocumentIdPhoto _documentIdPhoto;
+        private string _detectedCountry;
+        private SandboxDocumentTextDataExtractionRecommendation _recommendation;
 
         public SandboxDocumentTextDataExtractionTaskBuilder WithDocumentField(string key, object value)
         {
@@ -38,9 +40,21 @@ namespace Yoti.Auth.Sandbox.DocScan.Request.Task
             return this;
         }
 
+        public SandboxDocumentTextDataExtractionTaskBuilder WithDetectedCountry(string detectedCountry)
+        {
+            _detectedCountry = detectedCountry;
+            return this;
+        }
+
+        public SandboxDocumentTextDataExtractionTaskBuilder WithRecommendation(SandboxDocumentTextDataExtractionRecommendation recommendation)
+        {
+            _recommendation = recommendation;
+            return this;
+        }
+
         public SandboxDocumentTextDataExtractionTask Build()
         {
-            SandboxDocumentTextDataExtractionTaskResult result = new SandboxDocumentTextDataExtractionTaskResult(_documentFields, _documentIdPhoto);
+            SandboxDocumentTextDataExtractionTaskResult result = new SandboxDocumentTextDataExtractionTaskResult(_documentFields, _documentIdPhoto, _detectedCountry, _recommendation);
             return new SandboxDocumentTextDataExtractionTask(result, _documentFilter);
         }
     }

--- a/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentTextDataExtractionTaskResult.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxDocumentTextDataExtractionTaskResult.cs
@@ -11,12 +11,22 @@ namespace Yoti.Auth.Sandbox.DocScan.Request.Task
         [JsonProperty(PropertyName = "document_id_photo")]
         public SandboxDocumentIdPhoto DocumentIdPhoto { get; }
 
+        [JsonProperty(PropertyName = "detected_country")]
+        public string DetectedCountry { get; }
+
+        [JsonProperty(PropertyName = "recommendation")]
+        public SandboxDocumentTextDataExtractionRecommendation Recommendation { get; }
+
         public SandboxDocumentTextDataExtractionTaskResult(
             Dictionary<string, object> documentFields,
-            SandboxDocumentIdPhoto sandboxDocumentIdPhoto = null)
+            SandboxDocumentIdPhoto sandboxDocumentIdPhoto = null,
+            string detectedCountry = null,
+            SandboxDocumentTextDataExtractionRecommendation recommendation = null)
         {
             DocumentFields = documentFields;
             DocumentIdPhoto = sandboxDocumentIdPhoto;
+            DetectedCountry = detectedCountry;
+            Recommendation = recommendation;
         }
     }
 }

--- a/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxTaskResults.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/Task/SandboxTaskResults.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
 using Newtonsoft.Json;
+using Yoti.Auth.Constants;
 
 namespace Yoti.Auth.Sandbox.DocScan.Request.Task
 {
     public class SandboxTaskResults
     {
-        [JsonProperty(PropertyName = Constants.DocScanConstants.IdDocumentTextDataExtraction)]
+        [JsonProperty(PropertyName = DocScanConstants.IdDocumentTextDataExtraction)]
         public List<SandboxDocumentTextDataExtractionTask> TextDataExtractionTasks { get; }
 
         public SandboxTaskResults(List<SandboxDocumentTextDataExtractionTask> textDataExtractionTasks)

--- a/Yoti.Auth.Sandbox/Profile/Request/ExtraData/ThirdParty/SandboxAttributeIssuanceDetailsBuilder.cs
+++ b/Yoti.Auth.Sandbox/Profile/Request/ExtraData/ThirdParty/SandboxAttributeIssuanceDetailsBuilder.cs
@@ -20,7 +20,7 @@ namespace Yoti.Auth.Sandbox.Profile.Request.ExtraData.ThirdParty
 
         public SandboxAttributeIssuanceDetailsBuilder WithExpiryDate(DateTime expiryDate)
         {
-            _expiryDate = expiryDate.ToString(Constants.Format.RFC3339PatternMilli, DateTimeFormatInfo.InvariantInfo);
+            _expiryDate = expiryDate.ToString(Yoti.Auth.Constants.Format.RFC3339PatternMilli, DateTimeFormatInfo.InvariantInfo);
             return this;
         }
 

--- a/Yoti.Auth.Sandbox/Profile/SandboxClient.cs
+++ b/Yoti.Auth.Sandbox/Profile/SandboxClient.cs
@@ -12,7 +12,7 @@ namespace Yoti.Auth.Sandbox.Profile
     public class SandboxClient
     {
         private const string _yotiSandboxPathPrefix = "/sandbox/v1";
-        private readonly Uri _defaultSandboxApiUrl = new Uri(Constants.Api.DefaultYotiHost + _yotiSandboxPathPrefix);
+        private readonly Uri _defaultSandboxApiUrl = new Uri(Yoti.Auth.Constants.Api.DefaultYotiHost + _yotiSandboxPathPrefix);
         private readonly HttpClient _httpClient;
         internal Uri SandboxApiUri { get; private set; }
         private readonly string _sdkId;
@@ -50,7 +50,7 @@ namespace Yoti.Auth.Sandbox.Profile
                     .WithEndpoint($"/apps/{_sdkId}/tokens")
                     .WithHttpMethod(HttpMethod.Post)
                     .WithContent(body)
-                    .WithContentHeader(Constants.Api.ContentTypeHeader, Constants.Api.ContentTypeJson)
+                    .WithContentHeader(Yoti.Auth.Constants.Api.ContentTypeHeader, Yoti.Auth.Constants.Api.ContentTypeJson)
                     .Build();
 
                 HttpResponseMessage response = request.Execute(_httpClient).Result;


### PR DESCRIPTION
### Added
- Ability to specify in-session feedback

### Fixed
- `ConfigureSessionResponse` and `ConfigureApplicationResponse` now give more information about the error
