### PR TITLE
SDK-1992: Fix sandbox tests

### DIFF
--- a/Yoti.Auth.Sandbox.Tests/DocScan/DocScanSandboxClientTests.cs
+++ b/Yoti.Auth.Sandbox.Tests/DocScan/DocScanSandboxClientTests.cs
@@ -62,9 +62,11 @@ namespace Yoti.Auth.Sandbox.Tests.DocScan
                     .WithKeyPair(KeyPair.Get())
                     .Build();
 
-                docScanSandboxClient.ConfigureSessionResponse(
+                var ex = Record.Exception(() => docScanSandboxClient.ConfigureSessionResponse(
                     _someSessionId,
-                    _sandboxResponseConfig);
+                    _sandboxResponseConfig));
+
+                Assert.Null(ex);
             };
         }
 

--- a/Yoti.Auth.Sandbox/DocScan/Request/SandboxClient.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/SandboxClient.cs
@@ -58,13 +58,12 @@ namespace Yoti.Auth.Sandbox.DocScan.Request
                     Response.CreateYotiExceptionFromStatusCode<SandboxException>(response);
                 }
             }
+            catch (SandboxException)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
-                if (ex is SandboxException)
-                {
-                    throw;
-                }
-
                 throw new SandboxException(Properties.Resources.DocScanSessionResponseError, ex);
             }
         }
@@ -96,13 +95,12 @@ namespace Yoti.Auth.Sandbox.DocScan.Request
                     Response.CreateYotiExceptionFromStatusCode<SandboxException>(response);
                 }
             }
+            catch (SandboxException)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
-                if (ex is SandboxException)
-                {
-                    throw;
-                }
-
                 throw new SandboxException(Properties.Resources.DocScanApplicationResponseError, ex);
             }
         }

--- a/Yoti.Auth.Sandbox/DocScan/Request/SandboxClient.cs
+++ b/Yoti.Auth.Sandbox/DocScan/Request/SandboxClient.cs
@@ -32,54 +32,78 @@ namespace Yoti.Auth.Sandbox.DocScan.Request
 
         public void ConfigureSessionResponse(string sessionId, ResponseConfig sandboxExpection)
         {
-            string serializedSandboxResponseConfig = JsonConvert.SerializeObject(
+            try
+            {
+                string serializedSandboxResponseConfig = JsonConvert.SerializeObject(
                 sandboxExpection,
                 new JsonSerializerSettings
                 {
                     NullValueHandling = NullValueHandling.Ignore
                 });
-            byte[] body = Encoding.UTF8.GetBytes(serializedSandboxResponseConfig);
+                byte[] body = Encoding.UTF8.GetBytes(serializedSandboxResponseConfig);
 
-            Yoti.Auth.Web.Request request = new RequestBuilder()
-                .WithKeyPair(_keyPair)
-                .WithBaseUri(DocScanSandboxApiUrl)
-                .WithEndpoint($"/sessions/{sessionId}/response-config")
-                .WithHttpMethod(HttpMethod.Put)
-                .WithContent(body)
-                .WithQueryParam("sdkId", _sdkId)
-                .Build();
+                Yoti.Auth.Web.Request request = new RequestBuilder()
+                    .WithKeyPair(_keyPair)
+                    .WithBaseUri(DocScanSandboxApiUrl)
+                    .WithEndpoint($"/sessions/{sessionId}/response-config")
+                    .WithHttpMethod(HttpMethod.Put)
+                    .WithContent(body)
+                    .WithQueryParam("sdkId", _sdkId)
+                    .Build();
 
-            HttpResponseMessage response = request.Execute(_httpClient).Result;
+                HttpResponseMessage response = request.Execute(_httpClient).Result;
 
-            if (!response.IsSuccessStatusCode)
+                if (!response.IsSuccessStatusCode)
+                {
+                    Response.CreateYotiExceptionFromStatusCode<SandboxException>(response);
+                }
+            }
+            catch (Exception ex)
             {
-                Response.CreateYotiExceptionFromStatusCode<SandboxException>(response);
+                if (ex is SandboxException)
+                {
+                    throw;
+                }
+
+                throw new SandboxException(Properties.Resources.DocScanSessionResponseError, ex);
             }
         }
 
         public void ConfigureApplicationResponse(ResponseConfig sandboxExpection)
         {
-            string serializedSandboxResponseConfig = JsonConvert.SerializeObject(
+            try
+            {
+                string serializedSandboxResponseConfig = JsonConvert.SerializeObject(
                sandboxExpection,
                new JsonSerializerSettings
                {
                    NullValueHandling = NullValueHandling.Ignore
                });
-            byte[] body = Encoding.UTF8.GetBytes(serializedSandboxResponseConfig);
+                byte[] body = Encoding.UTF8.GetBytes(serializedSandboxResponseConfig);
 
-            Yoti.Auth.Web.Request request = new RequestBuilder()
-                .WithKeyPair(_keyPair)
-                .WithBaseUri(DocScanSandboxApiUrl)
-                .WithEndpoint($"/apps/{_sdkId}/response-config")
-                .WithHttpMethod(HttpMethod.Put)
-                .WithContent(body)
-                .Build();
+                Yoti.Auth.Web.Request request = new RequestBuilder()
+                    .WithKeyPair(_keyPair)
+                    .WithBaseUri(DocScanSandboxApiUrl)
+                    .WithEndpoint($"/apps/{_sdkId}/response-config")
+                    .WithHttpMethod(HttpMethod.Put)
+                    .WithContent(body)
+                    .Build();
 
-            HttpResponseMessage response = request.Execute(_httpClient).Result;
+                HttpResponseMessage response = request.Execute(_httpClient).Result;
 
-            if (!response.IsSuccessStatusCode)
+                if (!response.IsSuccessStatusCode)
+                {
+                    Response.CreateYotiExceptionFromStatusCode<SandboxException>(response);
+                }
+            }
+            catch (Exception ex)
             {
-                Response.CreateYotiExceptionFromStatusCode<SandboxException>(response);
+                if (ex is SandboxException)
+                {
+                    throw;
+                }
+
+                throw new SandboxException(Properties.Resources.DocScanApplicationResponseError, ex);
             }
         }
     }


### PR DESCRIPTION
### Fixed
- Tests where exception was being swallowed after recent update to something (MSTest?): use try/catch
- Cobertura warning fix: Add assertion to test